### PR TITLE
Particle effects: bubble gun, foam cannon, smokeable cigarette (multiplayer-synced)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -9,6 +9,7 @@ import { accessoryPalette } from './src/character-style.ts'
 import { graffitiColors, graffitiWallBounds, graffitiWallCount, maxGraffitiSplats } from './src/graffiti.ts'
 import { photoWallThumbnailHeight, photoWallThumbnailWidth } from './src/photo-wall-data.ts'
 import {
+  ACTIONS,
   ADMIN,
   BEACH_BALLS,
   C_HEARTBEAT,
@@ -16,6 +17,7 @@ import {
   C_ROOM_CHANGE,
   decodeAdminMessage,
   decodeBeachBalls,
+  decodeClientActions,
   decodeClientMessage,
   decodeClientMotion,
   decodeClientNickname,
@@ -30,6 +32,7 @@ import {
   encodeModerationMessage,
   encodeOnline,
   encodeRoomState,
+  encodeServerActions,
   encodeServerMessage,
   encodeServerMotion,
   encodeServerNickname,
@@ -363,6 +366,12 @@ const server = Bun.serve<SocketData>({
         if (type === NICKNAME) {
           touchInteraction(client)
           setNickname(client, decodeClientNickname(view))
+          return
+        }
+
+        if (type === ACTIONS) {
+          touchInteraction(client)
+          broadcast(client, encodeServerActions({ id: client.id, actions: decodeClientActions(view) & 0b11 }))
           return
         }
 

--- a/src/beach-balls.ts
+++ b/src/beach-balls.ts
@@ -1,9 +1,9 @@
 import { characterFloor } from './character-data.ts'
-import { reserveFloats } from './character-geometry.ts'
 import type { VertexWriter } from './character-geometry.ts'
 import { clamp } from './math.ts'
 import { outsideBounds } from './scene-data.ts'
 import { collideSphereRoom, walkHeight } from './scene.ts'
+import { createUnitSphere, reserveSphereFloats, writeSphere } from './sphere-geometry.ts'
 import type { BeachBall, CircleBounds, Vec3 } from './types.ts'
 
 export const beachBallRadius = 0.52
@@ -79,12 +79,11 @@ export function hitBeachBalls(balls: BeachBall[], player: Vec3) {
 }
 
 export function writeBeachBallGeometry(target: VertexWriter, balls: BeachBall[]) {
-  const verticesPerBall = beachBallRows * beachBallColumns * 6
-
-  reserveFloats(target, balls.length * verticesPerBall * 11)
+  reserveSphereFloats(target, beachBallUnitSphere, balls.length)
 
   for (const ball of balls) {
-    writeBeachBall(target, ball)
+    writeSphere(target, beachBallUnitSphere, ball.position[0], ball.position[1], ball.position[2], beachBallRadius,
+      palette[ball.id]!, glow)
   }
 }
 
@@ -112,69 +111,4 @@ function collideBallRoom(ball: BeachBall, outsideTree: CircleBounds) {
   }
 }
 
-const beachBallRows = 8
-const beachBallColumns = 16
-const beachBallUnitVertices = createBeachBallUnitVertices()
-
-function writeBeachBall(target: VertexWriter, ball: BeachBall) {
-  const color = palette[ball.id]!
-  const data = target.data
-  let offset = target.length
-
-  for (let i = 0; i < beachBallUnitVertices.length; i += 3) {
-    offset = writeVertex(data, offset, ball.position[0] + beachBallUnitVertices[i]! * beachBallRadius,
-      ball.position[1] + beachBallUnitVertices[i + 1]! * beachBallRadius,
-      ball.position[2] + beachBallUnitVertices[i + 2]! * beachBallRadius, color)
-  }
-
-  target.length = offset
-}
-
-function writeVertex(data: Float32Array, offset: number, x: number, y: number, z: number, color: Vec3) {
-  data[offset] = x
-  data[offset + 1] = y
-  data[offset + 2] = z
-  data[offset + 3] = color[0]
-  data[offset + 4] = color[1]
-  data[offset + 5] = color[2]
-  data[offset + 6] = glow
-  data[offset + 7] = 0
-  data[offset + 8] = 0
-  data[offset + 9] = 0
-  data[offset + 10] = 0
-
-  return offset + 11
-}
-
-function createBeachBallUnitVertices() {
-  const vertices: number[] = []
-
-  for (let y = 0; y < beachBallRows; y++) {
-    const top = -Math.PI / 2 + Math.PI * y / beachBallRows
-    const bottom = -Math.PI / 2 + Math.PI * (y + 1) / beachBallRows
-
-    for (let x = 0; x < beachBallColumns; x++) {
-      const left = Math.PI * 2 * x / beachBallColumns
-      const right = Math.PI * 2 * (x + 1) / beachBallColumns
-
-      addUnitQuad(vertices, top, bottom, left, right)
-    }
-  }
-
-  return new Float32Array(vertices)
-}
-
-function addUnitQuad(target: number[], top: number, bottom: number, left: number, right: number) {
-  addUnitPoint(target, top, left)
-  addUnitPoint(target, top, right)
-  addUnitPoint(target, bottom, right)
-  addUnitPoint(target, top, left)
-  addUnitPoint(target, bottom, right)
-  addUnitPoint(target, bottom, left)
-}
-
-function addUnitPoint(target: number[], vertical: number, horizontal: number) {
-  const radius = Math.cos(vertical)
-
-  target.push(Math.cos(horizontal) * radius, Math.sin(vertical), Math.sin(horizontal) * radius)
-}
+const beachBallUnitSphere = createUnitSphere(8, 16)

--- a/src/bubbles.ts
+++ b/src/bubbles.ts
@@ -1,0 +1,111 @@
+import type { VertexWriter } from './character-geometry.ts'
+import { createUnitSphere, reserveSphereFloats, writeSphere } from './sphere-geometry.ts'
+import type { Vec3 } from './types.ts'
+
+export type Bubble = {
+  position: Vec3
+  velocity: Vec3
+  radius: number
+  life: number
+  wobblePhase: number
+  wobbleRate: number
+  hue: number
+}
+
+const emitSpeed = 2.4
+const spread = 0.9
+const buoyancy = 1.1
+const wobbleStrength = 0.6
+const minRadius = 0.05
+const maxRadius = 0.12
+const minLife = 2
+const maxLife = 3.2
+const bubbleGlow = 1
+const unitSphere = createUnitSphere(6, 10)
+const color: Vec3 = [0, 0, 0]
+
+function createBubble(): Bubble {
+  return {
+    position: [0, 0, 0],
+    velocity: [0, 0, 0],
+    radius: 0,
+    life: 0,
+    wobblePhase: 0,
+    wobbleRate: 0,
+    hue: 0,
+  }
+}
+
+export function createBubbleSystem() {
+  const bubbles: Bubble[] = []
+  const pool: Bubble[] = []
+
+  // Bubbles drift, wobble and pop on their own, so the active count stays bounded
+  // by the fixed emit rate times the lifetime — no explicit cap needed.
+  function spawn(origin: Vec3, forward: Vec3, count: number) {
+    for (let i = 0; i < count; i++) {
+      const bubble = pool.pop() ?? createBubble()
+
+      bubble.position[0] = origin[0] + (Math.random() - 0.5) * 0.18
+      bubble.position[1] = origin[1] + (Math.random() - 0.5) * 0.18
+      bubble.position[2] = origin[2] + (Math.random() - 0.5) * 0.18
+      bubble.velocity[0] = forward[0] * emitSpeed + (Math.random() - 0.5) * spread
+      bubble.velocity[1] = forward[1] * emitSpeed + Math.random() * 0.4
+      bubble.velocity[2] = forward[2] * emitSpeed + (Math.random() - 0.5) * spread
+      bubble.radius = minRadius + Math.random() * (maxRadius - minRadius)
+      bubble.life = minLife + Math.random() * (maxLife - minLife)
+      bubble.wobblePhase = Math.random() * Math.PI * 2
+      bubble.wobbleRate = 2.4 + Math.random() * 2.6
+      bubble.hue = Math.random()
+      bubbles.push(bubble)
+    }
+  }
+
+  function update(delta: number) {
+    for (let i = bubbles.length - 1; i >= 0; i--) {
+      const bubble = bubbles[i]!
+
+      bubble.life -= delta
+      if (bubble.life <= 0) {
+        const last = bubbles.pop()!
+
+        if (i < bubbles.length) {
+          bubbles[i] = last
+        }
+        pool.push(bubble)
+        continue
+      }
+
+      bubble.wobblePhase += bubble.wobbleRate * delta
+      bubble.velocity[1] += buoyancy * delta
+      const damp = Math.exp(-0.7 * delta)
+
+      bubble.velocity[0] = bubble.velocity[0] * damp + Math.cos(bubble.wobblePhase) * wobbleStrength * delta
+      bubble.velocity[2] = bubble.velocity[2] * damp + Math.sin(bubble.wobblePhase) * wobbleStrength * delta
+      bubble.position[0] += bubble.velocity[0] * delta
+      bubble.position[1] += bubble.velocity[1] * delta
+      bubble.position[2] += bubble.velocity[2] * delta
+    }
+  }
+
+  return { bubbles, spawn, update }
+}
+
+export function writeBubbleGeometry(target: VertexWriter, bubbles: Bubble[]) {
+  reserveSphereFloats(target, unitSphere, bubbles.length)
+
+  for (const bubble of bubbles) {
+    writeSphere(target, unitSphere, bubble.position[0], bubble.position[1], bubble.position[2], bubble.radius,
+      bubbleColor(bubble.hue), bubbleGlow)
+  }
+}
+
+function bubbleColor(hue: number) {
+  const angle = hue * Math.PI * 2
+
+  color[0] = 0.6 + 0.4 * Math.sin(angle)
+  color[1] = 0.6 + 0.4 * Math.sin(angle + 2.094)
+  color[2] = 0.6 + 0.4 * Math.sin(angle + 4.188)
+
+  return color
+}

--- a/src/character-draw.ts
+++ b/src/character-draw.ts
@@ -514,31 +514,41 @@ function addCigaretteAtHand(
   const handSide = handSideSign(hand, torso, sideX, sideZ)
   const forwardX = turn.sin
   const forwardZ = turn.cos
-  const centerX = hand[0] + dx * 0.1 + forwardX * 0.04
-  const centerY = hand[1] + dy * 0.1 + 0.02
-  const centerZ = hand[2] + dz * 0.1 + forwardZ * 0.04
-  const length = 0.12
+  // Pinch it at the fingertips: reach past the wrist, tuck it into the grip and a little forward.
+  const baseX = hand[0] + dx * 0.18 + sideX * handSide * 0.05 + forwardX * 0.05
+  const baseY = hand[1] + dy * 0.18 + 0.03
+  const baseZ = hand[2] + dz * 0.18 + sideZ * handSide * 0.05 + forwardZ * 0.05
+  // Angle the cigarette forward and up so it reads as held, not lying flat.
+  let dirX = forwardX
+  let dirY = 0.5
+  let dirZ = forwardZ
+  const dirLength = Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ)
+
+  dirX /= dirLength
+  dirY /= dirLength
+  dirZ /= dirLength
+  const length = 0.1
 
   cigaretteSide[0] = sideX * handSide
   cigaretteSide[1] = 0
   cigaretteSide[2] = sideZ * handSide
-  cigaretteA[0] = centerX
-  cigaretteA[1] = centerY
-  cigaretteA[2] = centerZ
-  cigaretteB[0] = centerX + forwardX * length
-  cigaretteB[1] = centerY
-  cigaretteB[2] = centerZ + forwardZ * length
-  addCharacterBox(target, boxInstances, cigaretteA, cigaretteB, 0.022, 0.022, style.accessory!, 0.05, player.turn,
+  cigaretteA[0] = baseX
+  cigaretteA[1] = baseY
+  cigaretteA[2] = baseZ
+  cigaretteB[0] = baseX + dirX * length
+  cigaretteB[1] = baseY + dirY * length
+  cigaretteB[2] = baseZ + dirZ * length
+  addCharacterBox(target, boxInstances, cigaretteA, cigaretteB, 0.02, 0.02, style.accessory!, 0.05, player.turn,
     localReflection, light, 0, turn.sin, turn.cos, { side: cigaretteSide })
 
   cigaretteEmberA[0] = cigaretteB[0]
   cigaretteEmberA[1] = cigaretteB[1]
   cigaretteEmberA[2] = cigaretteB[2]
-  cigaretteEmberB[0] = cigaretteB[0] + forwardX * 0.02
-  cigaretteEmberB[1] = cigaretteB[1]
-  cigaretteEmberB[2] = cigaretteB[2] + forwardZ * 0.02
-  addCharacterBox(target, boxInstances, cigaretteEmberA, cigaretteEmberB, 0.026, 0.026, cigaretteEmber, 1.6, player.turn,
-    localReflection, light, 0, turn.sin, turn.cos, { side: cigaretteSide })
+  cigaretteEmberB[0] = cigaretteB[0] + dirX * 0.016
+  cigaretteEmberB[1] = cigaretteB[1] + dirY * 0.016
+  cigaretteEmberB[2] = cigaretteB[2] + dirZ * 0.016
+  addCharacterBox(target, boxInstances, cigaretteEmberA, cigaretteEmberB, 0.022, 0.022, cigaretteEmber, 1.6,
+    player.turn, localReflection, light, 0, turn.sin, turn.cos, { side: cigaretteSide })
 }
 
 function handSideSign(hand: Vec3, torso: Vec3, sideX: number, sideZ: number) {

--- a/src/character-draw.ts
+++ b/src/character-draw.ts
@@ -88,6 +88,8 @@ const leftLegIndex = poseJointIndices.get('mixamorig:LeftLeg')!
 const rightLegIndex = poseJointIndices.get('mixamorig:RightLeg')!
 const headIndex = poseJointIndices.get('mixamorig:Head')!
 const headTopIndex = poseJointIndices.get('mixamorig:HeadTop_End')!
+
+export const headPoseIndex = headIndex
 const characterPartPlans = characterParts.map(part => ({
   part,
   fromIndex: poseJointIndices.get(part.from)!,

--- a/src/character-draw.ts
+++ b/src/character-draw.ts
@@ -11,6 +11,7 @@ import { characterParts, characterPoseJoints, characterPoseJointSet } from './ch
 import { sampleBasePose, sampleCharacterPose } from './character-rig.ts'
 import { resolvePlayerStyle } from './character-style.ts'
 import { characterView, characterVisibilityInto } from './character-visibility.ts'
+import { cigaretteLift } from './cigarette.ts'
 import { clamp, normalizeIndex } from './math.ts'
 import { roomAt } from './scene.ts'
 import type {
@@ -113,6 +114,12 @@ const hairForward: Vec3 = [0, 0, 0]
 const glowstickA: Vec3 = [0, 0, 0]
 const glowstickB: Vec3 = [0, 0, 0]
 const glowstickSide: Vec3 = [0, 0, 0]
+const cigaretteA: Vec3 = [0, 0, 0]
+const cigaretteB: Vec3 = [0, 0, 0]
+const cigaretteEmberA: Vec3 = [0, 0, 0]
+const cigaretteEmberB: Vec3 = [0, 0, 0]
+const cigaretteSide: Vec3 = [0, 0, 0]
+const cigaretteEmber: Vec3 = [1, 0.36, 0.05]
 const sprayCanNozzleSide: Vec3 = [0, 1, 0]
 const sprayCanCapA: Vec3 = [0, 0, 0]
 const sprayCanCapB: Vec3 = [0, 0, 0]
@@ -272,6 +279,10 @@ function addRenderedCharacter(
     sin: Math.sin(player.turn),
   }
 
+  if (style.accessoryKind === 'cigarette') {
+    raiseCigaretteArm(pose, turn, options.time)
+  }
+
   for (const part of characterPartPlans) {
     if (style.bottomMode === 'pants' || !part.part.bottom) {
       addCharacterPart(target, boxInstances, pose, part, player, turn, style, options.light, localReflection)
@@ -289,6 +300,9 @@ function addRenderedCharacter(
   if (style.accessory) {
     if (style.accessoryKind === 'glowstick') {
       addGlowsticks(target, boxInstances, pose, player, turn, style, options.light, localReflection)
+    }
+    else if (style.accessoryKind === 'cigarette') {
+      addCigarette(target, boxInstances, pose, player, turn, style, options.light, localReflection)
     }
     else {
       addSprayCan(target, boxInstances, pose, player, turn, style, options.light, localReflection)
@@ -436,6 +450,95 @@ function addSprayCanAtHand(
   sprayCanNozzleB[2] = centerZ + sideZ * handSide * 0.13
   addCharacterBox(target, boxInstances, sprayCanNozzleA, sprayCanNozzleB, 0.035, 0.035, color, 0.12, player.turn,
     localReflection, light, 0, turn.sin, turn.cos, { side: sprayCanNozzleSide })
+}
+
+function raiseCigaretteArm(pose: Vec3[], turn: TurnBasis, time: number) {
+  const lift = cigaretteLift(time)
+
+  if (lift <= 0) {
+    return
+  }
+
+  const hand = pose[rightHandIndex]!
+  const foreArm = pose[rightForeArmIndex]!
+  const head = pose[headIndex]!
+  // Bring the cigarette hand up to the mouth, just in front of the lips.
+  const mouthX = head[0] + turn.sin * 0.05
+  const mouthY = head[1] - 0.08
+  const mouthZ = head[2] + turn.cos * 0.05
+  const deltaX = (mouthX - hand[0]) * lift
+  const deltaY = (mouthY - hand[1]) * lift
+  const deltaZ = (mouthZ - hand[2]) * lift
+
+  hand[0] += deltaX
+  hand[1] += deltaY
+  hand[2] += deltaZ
+  foreArm[0] += deltaX * 0.55
+  foreArm[1] += deltaY * 0.55
+  foreArm[2] += deltaZ * 0.55
+}
+
+function addCigarette(
+  target: VertexWriter,
+  boxInstances: VertexWriter,
+  pose: Vec3[],
+  player: { turn: number },
+  turn: TurnBasis,
+  style: ResolvedPlayerStyle,
+  light: CharacterLight,
+  localReflection: boolean,
+) {
+  const torso = pose[spine2Index]!
+
+  addCigaretteAtHand(target, boxInstances, torso, pose[rightForeArmIndex]!, pose[rightHandIndex]!, player, turn, style,
+    light, localReflection)
+}
+
+function addCigaretteAtHand(
+  target: VertexWriter,
+  boxInstances: VertexWriter,
+  torso: Vec3,
+  foreArm: Vec3,
+  hand: Vec3,
+  player: { turn: number },
+  turn: TurnBasis,
+  style: ResolvedPlayerStyle,
+  light: CharacterLight,
+  localReflection: boolean,
+) {
+  const dx = hand[0] - foreArm[0]
+  const dy = hand[1] - foreArm[1]
+  const dz = hand[2] - foreArm[2]
+  const sideX = turn.cos
+  const sideZ = -turn.sin
+  const handSide = handSideSign(hand, torso, sideX, sideZ)
+  const forwardX = turn.sin
+  const forwardZ = turn.cos
+  const centerX = hand[0] + dx * 0.1 + forwardX * 0.04
+  const centerY = hand[1] + dy * 0.1 + 0.02
+  const centerZ = hand[2] + dz * 0.1 + forwardZ * 0.04
+  const length = 0.12
+
+  cigaretteSide[0] = sideX * handSide
+  cigaretteSide[1] = 0
+  cigaretteSide[2] = sideZ * handSide
+  cigaretteA[0] = centerX
+  cigaretteA[1] = centerY
+  cigaretteA[2] = centerZ
+  cigaretteB[0] = centerX + forwardX * length
+  cigaretteB[1] = centerY
+  cigaretteB[2] = centerZ + forwardZ * length
+  addCharacterBox(target, boxInstances, cigaretteA, cigaretteB, 0.022, 0.022, style.accessory!, 0.05, player.turn,
+    localReflection, light, 0, turn.sin, turn.cos, { side: cigaretteSide })
+
+  cigaretteEmberA[0] = cigaretteB[0]
+  cigaretteEmberA[1] = cigaretteB[1]
+  cigaretteEmberA[2] = cigaretteB[2]
+  cigaretteEmberB[0] = cigaretteB[0] + forwardX * 0.02
+  cigaretteEmberB[1] = cigaretteB[1]
+  cigaretteEmberB[2] = cigaretteB[2] + forwardZ * 0.02
+  addCharacterBox(target, boxInstances, cigaretteEmberA, cigaretteEmberB, 0.026, 0.026, cigaretteEmber, 1.6, player.turn,
+    localReflection, light, 0, turn.sin, turn.cos, { side: cigaretteSide })
 }
 
 function handSideSign(hand: Vec3, torso: Vec3, sideX: number, sideZ: number) {

--- a/src/character-render-system.ts
+++ b/src/character-render-system.ts
@@ -6,7 +6,7 @@ import {
   loadCharacterDetails,
   loadCharacterHair,
 } from './character-assets.ts'
-import { buildCharacterDrawData } from './character-draw.ts'
+import { buildCharacterDrawData, headPoseIndex } from './character-draw.ts'
 import type { CharacterDrawCache } from './character-draw.ts'
 import type { VertexWriter } from './character-geometry.ts'
 import { uploadFloatBuffer } from './character-gpu.ts'
@@ -46,6 +46,7 @@ export function createCharacterRenderSystem(options: {
   let remainingDanceLoad: Promise<void> | undefined
   const danceLoads = new Map<number, Promise<void>>()
   let boxInstanceCount = 0
+  let headHeight = 1.1
   let assetsLoaded = false
   let coreLoadedChunks = 0
   let detailsLoaded = false
@@ -180,6 +181,11 @@ export function createCharacterRenderSystem(options: {
       width: options.canvas.width,
     })
 
+    const localHead = drawCache.poses[0]?.[headPoseIndex]
+
+    if (localHead) {
+      headHeight = localHead[1] - options.characterPosition[1]
+    }
     updateHairInstances(options.gl, hairRenderMeshes, data.hairInstances, hairInstanceCache)
     boxInstanceCount = data.boxInstances.length / options.boxInstanceSize
     uploadFloatBuffer(options.gl, options.boxInstanceBuffer, data.boxInstances.data, boxInstanceCache,
@@ -206,6 +212,9 @@ export function createCharacterRenderSystem(options: {
     },
     get boxInstanceCount() {
       return boxInstanceCount
+    },
+    get headHeight() {
+      return headHeight
     },
     get hairRenderMeshes() {
       return hairRenderMeshes

--- a/src/character-style.ts
+++ b/src/character-style.ts
@@ -16,7 +16,22 @@ export const glowstickColors: Vec3[] = [
   [1, 0.22, 0.04],
 ]
 export const sprayColors: Vec3[] = graffitiColors
-export const accessoryPalette: Vec3[] = [...glowstickColors, ...sprayColors]
+export const cigaretteColors: Vec3[] = [
+  [0.96, 0.96, 0.92],
+]
+export const accessoryPalette: Vec3[] = [...glowstickColors, ...sprayColors, ...cigaretteColors]
+
+export function resolveAccessoryKind(accessoryIndex: number): ResolvedPlayerStyle['accessoryKind'] {
+  const index = normalizeIndex(accessoryIndex, accessoryPalette.length + 1)
+
+  return index === 0
+    ? undefined
+    : index <= glowstickColors.length
+    ? 'glowstick'
+    : index <= glowstickColors.length + sprayColors.length
+    ? 'spray'
+    : 'cigarette'
+}
 
 export function createCharacterStyleController() {
   let shirtColorIndex = 0
@@ -134,11 +149,7 @@ export function resolvePlayerStyle(style: PlayerStyle): ResolvedPlayerStyle {
   const top = topStyleData(topIndex)
   const bottomMode: BottomMode = bottomIndex < jewelPalette.length ? 'pants' : 'skirt'
   const pantsColor = jewelPalette[bottomIndex % jewelPalette.length]!
-  const accessoryKind: ResolvedPlayerStyle['accessoryKind'] = accessoryIndex === 0
-    ? undefined
-    : accessoryIndex <= glowstickColors.length
-    ? 'glowstick'
-    : 'spray'
+  const accessoryKind = resolveAccessoryKind(accessoryIndex)
   const resolved = {
     topMode: top.mode,
     bottomMode,

--- a/src/cigarette.ts
+++ b/src/cigarette.ts
@@ -1,0 +1,47 @@
+// One slow puffing cycle: the cigarette rests in the hand, rises to the mouth
+// for a drag, holds, lowers again, then the smoker exhales a plume.
+const period = 6
+const liftStart = 1
+const liftEnd = 1.7
+const holdEnd = 2.9
+const lowerEnd = 3.6
+const exhaleEnd = 4.8
+
+export function cigarettePhase(time: number) {
+  return ((time % period) + period) % period
+}
+
+// 0 = cigarette resting at the hand, 1 = held at the mouth.
+export function cigaretteLift(time: number) {
+  const t = cigarettePhase(time)
+
+  if (t < liftStart) {
+    return 0
+  }
+  if (t < liftEnd) {
+    return smoothstep((t - liftStart) / (liftEnd - liftStart))
+  }
+  if (t < holdEnd) {
+    return 1
+  }
+  if (t < lowerEnd) {
+    return 1 - smoothstep((t - holdEnd) / (lowerEnd - holdEnd))
+  }
+
+  return 0
+}
+
+// 0 outside the exhale window, rising to 1 at the peak of the plume.
+export function cigaretteExhale(time: number) {
+  const t = cigarettePhase(time)
+
+  if (t < lowerEnd || t > exhaleEnd) {
+    return 0
+  }
+
+  return Math.sin((t - lowerEnd) / (exhaleEnd - lowerEnd) * Math.PI)
+}
+
+function smoothstep(x: number) {
+  return x * x * (3 - 2 * x)
+}

--- a/src/club-app.ts
+++ b/src/club-app.ts
@@ -7,6 +7,7 @@ import { createCharacterStyleController, glowstickColors } from './character-sty
 import { restoreClubState, saveClubState } from './club-persistence.ts'
 import { createSaveTimer, readClubState } from './club-state.ts'
 import { addRoom, addRoomSmoke, addWallStrips } from './environment-object.ts'
+import { createFoamSystem, writeFoamGeometry } from './foam.ts'
 import {
   addGraffitiWallGeometry,
   createGraffitiCanvas,
@@ -52,6 +53,8 @@ import {
   roomAt,
   seatAt,
   usesSkyBackground,
+  walkHeight,
+  walkLoftHeight,
 } from './scene.ts'
 import {
   characterBoxFragment,
@@ -141,6 +144,7 @@ const {
   breakdanceButton,
   waveButton,
   bubbleButton,
+  foamButton,
   photoButton,
   roomsButton,
   supportLink,
@@ -373,6 +377,7 @@ function syncOnlineIndicator() {
   breakdanceButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
   waveButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
   bubbleButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
+  foamButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
   photoButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
   roomsButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
   supportLink.dataset.hidden = String(helpUi.root.dataset.open === 'true')
@@ -1487,6 +1492,8 @@ const beachBallArray = gl.createVertexArray()
 const beachBallBuffer = gl.createBuffer()
 const bubbleArray = gl.createVertexArray()
 const bubbleBuffer = gl.createBuffer()
+const foamArray = gl.createVertexArray()
+const foamBuffer = gl.createBuffer()
 const graffitiArray = gl.createVertexArray()
 const graffitiBuffer = gl.createBuffer()
 const target = createTarget(gl, 1, 1)
@@ -1518,7 +1525,8 @@ if (!viewProjection || !cameraEye || !renderZone || !bloomPass || !doorCoverVisi
   || !buffer || !lightArray || !lightBuffer || !strobeArray || !strobeGeometryBuffer || !strobeInstanceBuffer
   || !smokeArray || !smokeBuffer || !characterArray || !characterBuffer
   || !characterBoxArray || !characterBoxGeometryBuffer || !characterBoxInstanceBuffer || !postArray || !postBuffer
-  || !beachBallArray || !beachBallBuffer || !bubbleArray || !bubbleBuffer || !graffitiArray || !graffitiBuffer)
+  || !beachBallArray || !beachBallBuffer || !bubbleArray || !bubbleBuffer || !foamArray || !foamBuffer
+  || !graffitiArray || !graffitiBuffer)
 {
   throw new Error('Failed to initialize WebGL resources')
 }
@@ -1588,6 +1596,7 @@ setupCharacterBoxArray({
 setupPostArray({ array: postArray, buffer: postBuffer, gl })
 setupVertexArray({ array: beachBallArray, buffer: beachBallBuffer, data: 0, gl, stride, usage: gl.DYNAMIC_DRAW })
 setupVertexArray({ array: bubbleArray, buffer: bubbleBuffer, data: 0, gl, stride, usage: gl.DYNAMIC_DRAW })
+setupVertexArray({ array: foamArray, buffer: foamBuffer, data: 0, gl, stride, usage: gl.DYNAMIC_DRAW })
 setupVertexArray({ array: graffitiArray, buffer: graffitiBuffer, data: graffitiPoints, gl, stride,
   usage: gl.STATIC_DRAW })
 
@@ -1718,6 +1727,15 @@ const bubbleForward: Vec3 = [0, 0, 0]
 const bubbleInterval = 55
 let bubbling = false
 let nextBubbleAt = 0
+const foamSystem = createFoamSystem()
+let foamPoints: Float32Array<ArrayBufferLike> = new Float32Array()
+const foamWriter: VertexWriter = { data: new Float32Array(0), length: 0 }
+const foamMuzzle: Vec3 = [0, 0, 0]
+const foamForward: Vec3 = [0, 0, 0]
+const foamInterval = 250
+const foamBurstCount = 22
+let foaming = false
+let nextFoamAt = 0
 const graffitiSplats: GraffitiSplat[] = []
 const graffitiIds = new Set<number>()
 let nextRemoteSeatSyncAt = 0
@@ -2460,6 +2478,12 @@ bindKeyboardInput({
   stopBubbles: () => {
     bubbling = false
   },
+  startFoam: () => {
+    foaming = true
+  },
+  stopFoam: () => {
+    foaming = false
+  },
   startBreakdance: () => localCharacter.startBreakdance(),
   openChatInput: () => openChatInput(),
   setAlternativeInput: useAlternativeInput,
@@ -2705,6 +2729,19 @@ bubbleButton.addEventListener('pointerdown', event => {
 for (const eventName of ['pointerup', 'pointercancel', 'lostpointercapture']) {
   bubbleButton.addEventListener(eventName, () => {
     bubbling = false
+  })
+}
+
+foamButton.addEventListener('pointerdown', event => {
+  event.preventDefault()
+  foamButton.setPointerCapture(event.pointerId)
+  foaming = true
+  canvas.focus()
+})
+
+for (const eventName of ['pointerup', 'pointercancel', 'lostpointercapture']) {
+  foamButton.addEventListener(eventName, () => {
+    foaming = false
   })
 }
 
@@ -3042,6 +3079,7 @@ function renderCurrentSceneFrame(options: {
       post: postArray,
       beachBalls: beachBallArray,
       bubbles: bubbleArray,
+      foam: foamArray,
       graffiti: graffitiArray,
       room: array,
       smoke: smokeArray,
@@ -3078,6 +3116,7 @@ function renderCurrentSceneFrame(options: {
     points,
     beachBallPoints,
     bubblePoints,
+    foamPoints,
     graffitiPoints: options.inLoft ? emptyPoints : graffitiPoints,
     graffitiTexture,
     post: {
@@ -3202,6 +3241,11 @@ const draw = (stamp: number) => {
     emitBubbles()
   }
   bubbleSystem.update(delta)
+  if (foaming && stamp >= nextFoamAt) {
+    nextFoamAt = stamp + foamInterval
+    emitFoam()
+  }
+  foamSystem.update(delta, inLoft ? loftFloorAt : mainFloorAt)
   const hits = inLoft ? [] : hitBeachBalls(beachBalls, characterPosition)
 
   for (const id of hits) {
@@ -3306,6 +3350,7 @@ const draw = (stamp: number) => {
   const characterCount = characterRenderSystem.update(stamp * 0.001)
   updateBeachBallBuffer()
   updateBubbleBuffer()
+  updateFoamBuffer()
   if (!introHidden) {
     updateIntro()
   }
@@ -3344,6 +3389,36 @@ function updateBubbleBuffer() {
   bubblePoints = vertexWriterData(bubbleWriter)
   gl.bindBuffer(gl.ARRAY_BUFFER, bubbleBuffer)
   gl.bufferData(gl.ARRAY_BUFFER, bubblePoints, gl.DYNAMIC_DRAW)
+}
+
+function mainFloorAt(x: number, y: number, z: number) {
+  return walkHeight(x, y, z)
+}
+
+function loftFloorAt(x: number, y: number, z: number) {
+  return walkLoftHeight(x, y, z)
+}
+
+function emitFoam() {
+  const turn = localCharacter.turn
+  const forwardX = Math.sin(turn)
+  const forwardZ = Math.cos(turn)
+
+  foamMuzzle[0] = characterPosition[0] + forwardX * 0.45
+  foamMuzzle[1] = characterPosition[1] + 1.1
+  foamMuzzle[2] = characterPosition[2] + forwardZ * 0.45
+  foamForward[0] = forwardX
+  foamForward[1] = 0
+  foamForward[2] = forwardZ
+  foamSystem.burst(foamMuzzle, foamForward, foamBurstCount)
+}
+
+function updateFoamBuffer() {
+  resetVertexWriter(foamWriter)
+  writeFoamGeometry(foamWriter, foamSystem.blobs)
+  foamPoints = vertexWriterData(foamWriter)
+  gl.bindBuffer(gl.ARRAY_BUFFER, foamBuffer)
+  gl.bufferData(gl.ARRAY_BUFFER, foamPoints, gl.DYNAMIC_DRAW)
 }
 
 function updateBeachBallBuffer() {

--- a/src/club-app.ts
+++ b/src/club-app.ts
@@ -3450,7 +3450,7 @@ function emitPlayerParticles(
     if (stamp >= timers.smokeWisp) {
       timers.smokeWisp = stamp + smokeInterval
       smokeTip[0] = position[0] + forwardX * 0.22
-      smokeTip[1] = position[1] + 1 + lift * 0.5
+      smokeTip[1] = position[1] + 0.9 + lift * 0.45
       smokeTip[2] = position[2] + forwardZ * 0.22
       smokeSystem.emit(smokeTip, smokeForward, 1, false)
     }
@@ -3458,7 +3458,7 @@ function emitPlayerParticles(
     if (exhale > 0 && stamp >= timers.smokeExhale) {
       timers.smokeExhale = stamp + smokeExhaleInterval
       smokeMouth[0] = position[0] + forwardX * 0.18
-      smokeMouth[1] = position[1] + 1.5
+      smokeMouth[1] = position[1] + 1.35
       smokeMouth[2] = position[2] + forwardZ * 0.18
       smokeSystem.emit(smokeMouth, smokeForward, 1 + Math.floor(exhale * 3), true)
     }

--- a/src/club-app.ts
+++ b/src/club-app.ts
@@ -3442,6 +3442,11 @@ function emitPlayerParticles(
     const time = stamp * 0.001
     const lift = cigaretteLift(time)
     const exhale = cigaretteExhale(time)
+    // Heights measured from the actual rig: mouth just below the head joint,
+    // hand hanging around mid-body. The wisp tracks the cigarette from the hand
+    // up to the mouth as it is raised for a drag.
+    const mouthHeight = characterRenderSystem.headHeight - 0.1
+    const handHeight = characterRenderSystem.headHeight * 0.5
 
     smokeForward[0] = forwardX
     smokeForward[1] = 0
@@ -3450,7 +3455,7 @@ function emitPlayerParticles(
     if (stamp >= timers.smokeWisp) {
       timers.smokeWisp = stamp + smokeInterval
       smokeTip[0] = position[0] + forwardX * 0.22
-      smokeTip[1] = position[1] + 0.9 + lift * 0.45
+      smokeTip[1] = position[1] + handHeight + lift * (mouthHeight - handHeight)
       smokeTip[2] = position[2] + forwardZ * 0.22
       smokeSystem.emit(smokeTip, smokeForward, 1, false)
     }
@@ -3458,7 +3463,7 @@ function emitPlayerParticles(
     if (exhale > 0 && stamp >= timers.smokeExhale) {
       timers.smokeExhale = stamp + smokeExhaleInterval
       smokeMouth[0] = position[0] + forwardX * 0.18
-      smokeMouth[1] = position[1] + 1.35
+      smokeMouth[1] = position[1] + mouthHeight
       smokeMouth[2] = position[2] + forwardZ * 0.18
       smokeSystem.emit(smokeMouth, smokeForward, 1 + Math.floor(exhale * 3), true)
     }

--- a/src/club-app.ts
+++ b/src/club-app.ts
@@ -114,6 +114,7 @@ import { createIntroEffect } from './intro-effect.ts'
 import { createLocalCharacter } from './local-character.ts'
 import { createPhotoWallRenderer } from './photo-wall-renderer.ts'
 import { createPhotoWallUi } from './photo-wall-ui.ts'
+import { ACTION_BUBBLING, ACTION_FOAMING } from './protocol.ts'
 import type { VideoEndedEntry } from './protocol.ts'
 import { createSceneLighting } from './scene-lighting.ts'
 import { createStrobeDrawController } from './strobe-draw.ts'
@@ -1731,7 +1732,6 @@ const bubbleMuzzle: Vec3 = [0, 0, 0]
 const bubbleForward: Vec3 = [0, 0, 0]
 const bubbleInterval = 55
 let bubbling = false
-let nextBubbleAt = 0
 const foamSystem = createFoamSystem()
 let foamPoints: Float32Array<ArrayBufferLike> = new Float32Array()
 const foamWriter: VertexWriter = { data: new Float32Array(0), length: 0 }
@@ -1740,7 +1740,6 @@ const foamForward: Vec3 = [0, 0, 0]
 const foamInterval = 250
 const foamBurstCount = 22
 let foaming = false
-let nextFoamAt = 0
 const smokeSystem = createSmokeSystem()
 let smokePuffPoints: Float32Array<ArrayBufferLike> = new Float32Array()
 const smokeWriter: VertexWriter = { data: new Float32Array(0), length: 0 }
@@ -1749,8 +1748,9 @@ const smokeMouth: Vec3 = [0, 0, 0]
 const smokeForward: Vec3 = [0, 0, 0]
 const smokeInterval = 120
 const smokeExhaleInterval = 45
-let nextSmokeAt = 0
-let nextSmokeExhaleAt = 0
+type ParticleTimers = { bubble: number; foam: number; smokeWisp: number; smokeExhale: number }
+const particleTimers = new Map<number, ParticleTimers>()
+const localParticleSource = -1
 const graffitiSplats: GraffitiSplat[] = []
 const graffitiIds = new Set<number>()
 let nextRemoteSeatSyncAt = 0
@@ -1784,6 +1784,7 @@ function connectMultiplayer(spaceSlug?: string) {
     localInput: localCharacter.input,
     localMode: () => localCharacter.mode,
     localIdleClipIndex: () => idleClipIndex,
+    localActions: () => (bubbling ? ACTION_BUBBLING : 0) | (foaming ? ACTION_FOAMING : 0),
     localNickname: () => nickname,
     localStyle: () => ({
       topStyleIndex: styleController.topStyleIndex,
@@ -1845,6 +1846,7 @@ function connectMultiplayer(spaceSlug?: string) {
     onLeave: id => {
       nicknameLabelCache.delete(id)
       chatUi.remove(id)
+      particleTimers.delete(id)
     },
     onOnlineCount: online => {
       onlineCountValue = online.count
@@ -3253,19 +3255,14 @@ const draw = (stamp: number) => {
   if (!inLoft) {
     updateBeachBalls(beachBalls, delta, outsideTree)
   }
-  if (bubbling && stamp >= nextBubbleAt) {
-    nextBubbleAt = stamp + bubbleInterval
-    emitBubbles()
+  emitPlayerParticles(localParticleSource, characterPosition, localCharacter.turn, stamp, bubbling, foaming,
+    introHidden && resolveAccessoryKind(styleController.accessoryIndex) === 'cigarette')
+  for (const player of multiplayer.players.values()) {
+    emitPlayerParticles(player.id, player.position, player.turn, stamp, player.bubbling ?? false,
+      player.foaming ?? false, resolveAccessoryKind(player.style.accessoryIndex) === 'cigarette')
   }
   bubbleSystem.update(delta)
-  if (foaming && stamp >= nextFoamAt) {
-    nextFoamAt = stamp + foamInterval
-    emitFoam()
-  }
   foamSystem.update(delta, inLoft ? loftFloorAt : mainFloorAt)
-  if (introHidden && resolveAccessoryKind(styleController.accessoryIndex) === 'cigarette') {
-    emitCigaretteSmoke(stamp)
-  }
   smokeSystem.update(delta)
   const hits = inLoft ? [] : hitBeachBalls(beachBalls, characterPosition)
 
@@ -3292,6 +3289,7 @@ const draw = (stamp: number) => {
   else {
     multiplayer.sendMotionIfKeysChanged()
   }
+  multiplayer.sendActionsIfChanged()
 
   if (!inLoft) {
     updatePlayers(npcPlayers, delta, stamp * 0.001, outsideTree, occupiedSeats)
@@ -3391,18 +3389,80 @@ const draw = (stamp: number) => {
   scheduleFrame()
 }
 
-function emitBubbles() {
-  const turn = localCharacter.turn
+// Emit each particle effect a player is currently producing, from their own
+// position. Driven by synced state, so this runs identically for the local
+// player and every remote player. Per-source timers keep the emit rates steady.
+function emitPlayerParticles(
+  source: number,
+  position: Vec3,
+  turn: number,
+  stamp: number,
+  isBubbling: boolean,
+  isFoaming: boolean,
+  isSmoking: boolean,
+) {
+  if (!isBubbling && !isFoaming && !isSmoking) {
+    particleTimers.delete(source)
+    return
+  }
+
+  let timers = particleTimers.get(source)
+
+  if (!timers) {
+    timers = { bubble: 0, foam: 0, smokeWisp: 0, smokeExhale: 0 }
+    particleTimers.set(source, timers)
+  }
+
   const forwardX = Math.sin(turn)
   const forwardZ = Math.cos(turn)
 
-  bubbleMuzzle[0] = characterPosition[0] + forwardX * 0.35
-  bubbleMuzzle[1] = characterPosition[1] + 1.15
-  bubbleMuzzle[2] = characterPosition[2] + forwardZ * 0.35
-  bubbleForward[0] = forwardX
-  bubbleForward[1] = 0.35
-  bubbleForward[2] = forwardZ
-  bubbleSystem.spawn(bubbleMuzzle, bubbleForward, 3)
+  if (isBubbling && stamp >= timers.bubble) {
+    timers.bubble = stamp + bubbleInterval
+    bubbleMuzzle[0] = position[0] + forwardX * 0.35
+    bubbleMuzzle[1] = position[1] + 1.15
+    bubbleMuzzle[2] = position[2] + forwardZ * 0.35
+    bubbleForward[0] = forwardX
+    bubbleForward[1] = 0.35
+    bubbleForward[2] = forwardZ
+    bubbleSystem.spawn(bubbleMuzzle, bubbleForward, 3)
+  }
+
+  if (isFoaming && stamp >= timers.foam) {
+    timers.foam = stamp + foamInterval
+    foamMuzzle[0] = position[0] + forwardX * 0.45
+    foamMuzzle[1] = position[1] + 1.1
+    foamMuzzle[2] = position[2] + forwardZ * 0.45
+    foamForward[0] = forwardX
+    foamForward[1] = 0
+    foamForward[2] = forwardZ
+    foamSystem.burst(foamMuzzle, foamForward, foamBurstCount)
+  }
+
+  if (isSmoking) {
+    const time = stamp * 0.001
+    const lift = cigaretteLift(time)
+    const exhale = cigaretteExhale(time)
+
+    smokeForward[0] = forwardX
+    smokeForward[1] = 0
+    smokeForward[2] = forwardZ
+
+    if (stamp >= timers.smokeWisp) {
+      timers.smokeWisp = stamp + smokeInterval
+      smokeTip[0] = position[0] + forwardX * 0.22
+      smokeTip[1] = position[1] + 1 + lift * 0.5
+      smokeTip[2] = position[2] + forwardZ * 0.22
+      smokeSystem.emit(smokeTip, smokeForward, 1, false)
+    }
+
+    if (exhale > 0 && stamp >= timers.smokeExhale) {
+      timers.smokeExhale = stamp + smokeExhaleInterval
+      smokeMouth[0] = position[0] + forwardX * 0.18
+      smokeMouth[1] = position[1] + 1.5
+      smokeMouth[2] = position[2] + forwardZ * 0.18
+      smokeSystem.emit(smokeMouth, smokeForward, 1 + Math.floor(exhale * 3), true)
+    }
+  }
 }
 
 function updateBubbleBuffer() {
@@ -3421,55 +3481,12 @@ function loftFloorAt(x: number, y: number, z: number) {
   return walkLoftHeight(x, y, z)
 }
 
-function emitFoam() {
-  const turn = localCharacter.turn
-  const forwardX = Math.sin(turn)
-  const forwardZ = Math.cos(turn)
-
-  foamMuzzle[0] = characterPosition[0] + forwardX * 0.45
-  foamMuzzle[1] = characterPosition[1] + 1.1
-  foamMuzzle[2] = characterPosition[2] + forwardZ * 0.45
-  foamForward[0] = forwardX
-  foamForward[1] = 0
-  foamForward[2] = forwardZ
-  foamSystem.burst(foamMuzzle, foamForward, foamBurstCount)
-}
-
 function updateFoamBuffer() {
   resetVertexWriter(foamWriter)
   writeFoamGeometry(foamWriter, foamSystem.blobs)
   foamPoints = vertexWriterData(foamWriter)
   gl.bindBuffer(gl.ARRAY_BUFFER, foamBuffer)
   gl.bufferData(gl.ARRAY_BUFFER, foamPoints, gl.DYNAMIC_DRAW)
-}
-
-function emitCigaretteSmoke(stamp: number) {
-  const time = stamp * 0.001
-  const turn = localCharacter.turn
-  const forwardX = Math.sin(turn)
-  const forwardZ = Math.cos(turn)
-  const lift = cigaretteLift(time)
-  const exhale = cigaretteExhale(time)
-
-  smokeForward[0] = forwardX
-  smokeForward[1] = 0
-  smokeForward[2] = forwardZ
-
-  if (stamp >= nextSmokeAt) {
-    nextSmokeAt = stamp + smokeInterval
-    smokeTip[0] = characterPosition[0] + forwardX * 0.22
-    smokeTip[1] = characterPosition[1] + 1 + lift * 0.5
-    smokeTip[2] = characterPosition[2] + forwardZ * 0.22
-    smokeSystem.emit(smokeTip, smokeForward, 1, false)
-  }
-
-  if (exhale > 0 && stamp >= nextSmokeExhaleAt) {
-    nextSmokeExhaleAt = stamp + smokeExhaleInterval
-    smokeMouth[0] = characterPosition[0] + forwardX * 0.18
-    smokeMouth[1] = characterPosition[1] + 1.5
-    smokeMouth[2] = characterPosition[2] + forwardZ * 0.18
-    smokeSystem.emit(smokeMouth, smokeForward, 1 + Math.floor(exhale * 3), true)
-  }
 }
 
 function updateSmokeBuffer() {

--- a/src/club-app.ts
+++ b/src/club-app.ts
@@ -1,5 +1,6 @@
 import { createAdaptiveBloomScale, createAdaptivePixelRatio } from './adaptive-pixel-ratio.ts'
 import { createBeachBalls, hitBeachBalls, updateBeachBalls, writeBeachBallGeometry } from './beach-balls.ts'
+import { createBubbleSystem, writeBubbleGeometry } from './bubbles.ts'
 import { characterCoreChunkCount, idleClipNames } from './character-assets.ts'
 import { resetVertexWriter, vertexWriterData } from './character-geometry.ts'
 import { createCharacterStyleController, glowstickColors } from './character-style.ts'
@@ -139,6 +140,7 @@ const {
   reactionButtons,
   breakdanceButton,
   waveButton,
+  bubbleButton,
   photoButton,
   roomsButton,
   supportLink,
@@ -370,6 +372,7 @@ function syncOnlineIndicator() {
   reactionButtons.dataset.hidden = String(helpUi.root.dataset.open === 'true')
   breakdanceButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
   waveButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
+  bubbleButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
   photoButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
   roomsButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
   supportLink.dataset.hidden = String(helpUi.root.dataset.open === 'true')
@@ -1482,6 +1485,8 @@ const postArray = gl.createVertexArray()
 const postBuffer = gl.createBuffer()
 const beachBallArray = gl.createVertexArray()
 const beachBallBuffer = gl.createBuffer()
+const bubbleArray = gl.createVertexArray()
+const bubbleBuffer = gl.createBuffer()
 const graffitiArray = gl.createVertexArray()
 const graffitiBuffer = gl.createBuffer()
 const target = createTarget(gl, 1, 1)
@@ -1513,7 +1518,7 @@ if (!viewProjection || !cameraEye || !renderZone || !bloomPass || !doorCoverVisi
   || !buffer || !lightArray || !lightBuffer || !strobeArray || !strobeGeometryBuffer || !strobeInstanceBuffer
   || !smokeArray || !smokeBuffer || !characterArray || !characterBuffer
   || !characterBoxArray || !characterBoxGeometryBuffer || !characterBoxInstanceBuffer || !postArray || !postBuffer
-  || !beachBallArray || !beachBallBuffer || !graffitiArray || !graffitiBuffer)
+  || !beachBallArray || !beachBallBuffer || !bubbleArray || !bubbleBuffer || !graffitiArray || !graffitiBuffer)
 {
   throw new Error('Failed to initialize WebGL resources')
 }
@@ -1582,6 +1587,7 @@ setupCharacterBoxArray({
 })
 setupPostArray({ array: postArray, buffer: postBuffer, gl })
 setupVertexArray({ array: beachBallArray, buffer: beachBallBuffer, data: 0, gl, stride, usage: gl.DYNAMIC_DRAW })
+setupVertexArray({ array: bubbleArray, buffer: bubbleBuffer, data: 0, gl, stride, usage: gl.DYNAMIC_DRAW })
 setupVertexArray({ array: graffitiArray, buffer: graffitiBuffer, data: graffitiPoints, gl, stride,
   usage: gl.STATIC_DRAW })
 
@@ -1704,6 +1710,14 @@ let beachBallPoints: Float32Array<ArrayBufferLike> = new Float32Array()
 const beachBallWriter: VertexWriter = { data: new Float32Array(0), length: 0 }
 const beachBallAuthorityUntil = new Map<number, number>()
 const beachBallAuthorityDuration = 2000
+const bubbleSystem = createBubbleSystem()
+let bubblePoints: Float32Array<ArrayBufferLike> = new Float32Array()
+const bubbleWriter: VertexWriter = { data: new Float32Array(0), length: 0 }
+const bubbleMuzzle: Vec3 = [0, 0, 0]
+const bubbleForward: Vec3 = [0, 0, 0]
+const bubbleInterval = 55
+let bubbling = false
+let nextBubbleAt = 0
 const graffitiSplats: GraffitiSplat[] = []
 const graffitiIds = new Set<number>()
 let nextRemoteSeatSyncAt = 0
@@ -2440,6 +2454,12 @@ bindKeyboardInput({
   stopJumping: () => localCharacter.stopJumping(),
   startWave: () => localCharacter.startWave(),
   stopWave: () => localCharacter.stopWave(),
+  startBubbles: () => {
+    bubbling = true
+  },
+  stopBubbles: () => {
+    bubbling = false
+  },
   startBreakdance: () => localCharacter.startBreakdance(),
   openChatInput: () => openChatInput(),
   setAlternativeInput: useAlternativeInput,
@@ -2672,6 +2692,19 @@ for (const eventName of ['pointerup', 'pointercancel', 'lostpointercapture']) {
   waveButton.addEventListener(eventName, () => {
     localCharacter.stopWave()
     multiplayer.sendMotion()
+  })
+}
+
+bubbleButton.addEventListener('pointerdown', event => {
+  event.preventDefault()
+  bubbleButton.setPointerCapture(event.pointerId)
+  bubbling = true
+  canvas.focus()
+})
+
+for (const eventName of ['pointerup', 'pointercancel', 'lostpointercapture']) {
+  bubbleButton.addEventListener(eventName, () => {
+    bubbling = false
   })
 }
 
@@ -3008,6 +3041,7 @@ function renderCurrentSceneFrame(options: {
       light: lightArray,
       post: postArray,
       beachBalls: beachBallArray,
+      bubbles: bubbleArray,
       graffiti: graffitiArray,
       room: array,
       smoke: smokeArray,
@@ -3043,6 +3077,7 @@ function renderCurrentSceneFrame(options: {
     renderZone: renderZoneIndex(options.zone),
     points,
     beachBallPoints,
+    bubblePoints,
     graffitiPoints: options.inLoft ? emptyPoints : graffitiPoints,
     graffitiTexture,
     post: {
@@ -3162,6 +3197,11 @@ const draw = (stamp: number) => {
   if (!inLoft) {
     updateBeachBalls(beachBalls, delta, outsideTree)
   }
+  if (bubbling && stamp >= nextBubbleAt) {
+    nextBubbleAt = stamp + bubbleInterval
+    emitBubbles()
+  }
+  bubbleSystem.update(delta)
   const hits = inLoft ? [] : hitBeachBalls(beachBalls, characterPosition)
 
   for (const id of hits) {
@@ -3265,6 +3305,7 @@ const draw = (stamp: number) => {
 
   const characterCount = characterRenderSystem.update(stamp * 0.001)
   updateBeachBallBuffer()
+  updateBubbleBuffer()
   if (!introHidden) {
     updateIntro()
   }
@@ -3281,6 +3322,28 @@ const draw = (stamp: number) => {
   })
 
   scheduleFrame()
+}
+
+function emitBubbles() {
+  const turn = localCharacter.turn
+  const forwardX = Math.sin(turn)
+  const forwardZ = Math.cos(turn)
+
+  bubbleMuzzle[0] = characterPosition[0] + forwardX * 0.35
+  bubbleMuzzle[1] = characterPosition[1] + 1.15
+  bubbleMuzzle[2] = characterPosition[2] + forwardZ * 0.35
+  bubbleForward[0] = forwardX
+  bubbleForward[1] = 0.35
+  bubbleForward[2] = forwardZ
+  bubbleSystem.spawn(bubbleMuzzle, bubbleForward, 3)
+}
+
+function updateBubbleBuffer() {
+  resetVertexWriter(bubbleWriter)
+  writeBubbleGeometry(bubbleWriter, bubbleSystem.bubbles)
+  bubblePoints = vertexWriterData(bubbleWriter)
+  gl.bindBuffer(gl.ARRAY_BUFFER, bubbleBuffer)
+  gl.bufferData(gl.ARRAY_BUFFER, bubblePoints, gl.DYNAMIC_DRAW)
 }
 
 function updateBeachBallBuffer() {

--- a/src/club-app.ts
+++ b/src/club-app.ts
@@ -3,11 +3,13 @@ import { createBeachBalls, hitBeachBalls, updateBeachBalls, writeBeachBallGeomet
 import { createBubbleSystem, writeBubbleGeometry } from './bubbles.ts'
 import { characterCoreChunkCount, idleClipNames } from './character-assets.ts'
 import { resetVertexWriter, vertexWriterData } from './character-geometry.ts'
-import { createCharacterStyleController, glowstickColors } from './character-style.ts'
+import { createCharacterStyleController, glowstickColors, resolveAccessoryKind } from './character-style.ts'
+import { cigaretteExhale, cigaretteLift } from './cigarette.ts'
 import { restoreClubState, saveClubState } from './club-persistence.ts'
 import { createSaveTimer, readClubState } from './club-state.ts'
 import { addRoom, addRoomSmoke, addWallStrips } from './environment-object.ts'
 import { createFoamSystem, writeFoamGeometry } from './foam.ts'
+import { createSmokeSystem, writeSmokeGeometry } from './smoke-puff.ts'
 import {
   addGraffitiWallGeometry,
   createGraffitiCanvas,
@@ -1494,6 +1496,8 @@ const bubbleArray = gl.createVertexArray()
 const bubbleBuffer = gl.createBuffer()
 const foamArray = gl.createVertexArray()
 const foamBuffer = gl.createBuffer()
+const smokePuffArray = gl.createVertexArray()
+const smokePuffBuffer = gl.createBuffer()
 const graffitiArray = gl.createVertexArray()
 const graffitiBuffer = gl.createBuffer()
 const target = createTarget(gl, 1, 1)
@@ -1526,7 +1530,7 @@ if (!viewProjection || !cameraEye || !renderZone || !bloomPass || !doorCoverVisi
   || !smokeArray || !smokeBuffer || !characterArray || !characterBuffer
   || !characterBoxArray || !characterBoxGeometryBuffer || !characterBoxInstanceBuffer || !postArray || !postBuffer
   || !beachBallArray || !beachBallBuffer || !bubbleArray || !bubbleBuffer || !foamArray || !foamBuffer
-  || !graffitiArray || !graffitiBuffer)
+  || !smokePuffArray || !smokePuffBuffer || !graffitiArray || !graffitiBuffer)
 {
   throw new Error('Failed to initialize WebGL resources')
 }
@@ -1597,6 +1601,7 @@ setupPostArray({ array: postArray, buffer: postBuffer, gl })
 setupVertexArray({ array: beachBallArray, buffer: beachBallBuffer, data: 0, gl, stride, usage: gl.DYNAMIC_DRAW })
 setupVertexArray({ array: bubbleArray, buffer: bubbleBuffer, data: 0, gl, stride, usage: gl.DYNAMIC_DRAW })
 setupVertexArray({ array: foamArray, buffer: foamBuffer, data: 0, gl, stride, usage: gl.DYNAMIC_DRAW })
+setupVertexArray({ array: smokePuffArray, buffer: smokePuffBuffer, data: 0, gl, stride, usage: gl.DYNAMIC_DRAW })
 setupVertexArray({ array: graffitiArray, buffer: graffitiBuffer, data: graffitiPoints, gl, stride,
   usage: gl.STATIC_DRAW })
 
@@ -1736,6 +1741,16 @@ const foamInterval = 250
 const foamBurstCount = 22
 let foaming = false
 let nextFoamAt = 0
+const smokeSystem = createSmokeSystem()
+let smokePuffPoints: Float32Array<ArrayBufferLike> = new Float32Array()
+const smokeWriter: VertexWriter = { data: new Float32Array(0), length: 0 }
+const smokeTip: Vec3 = [0, 0, 0]
+const smokeMouth: Vec3 = [0, 0, 0]
+const smokeForward: Vec3 = [0, 0, 0]
+const smokeInterval = 120
+const smokeExhaleInterval = 45
+let nextSmokeAt = 0
+let nextSmokeExhaleAt = 0
 const graffitiSplats: GraffitiSplat[] = []
 const graffitiIds = new Set<number>()
 let nextRemoteSeatSyncAt = 0
@@ -2513,7 +2528,7 @@ createMobileControls({
 })
 bindTapDestination({
   canvas,
-  ignorePointer: event => styleController.accessoryIndex > glowstickColors.length,
+  ignorePointer: event => resolveAccessoryKind(styleController.accessoryIndex) === 'spray',
   jump: target => {
     localCharacter.jumpToward(target)
     multiplayer.sendMotion()
@@ -2533,7 +2548,7 @@ canvas.addEventListener('pointerdown', event => {
     return
   }
 
-  if (styleController.accessoryIndex <= glowstickColors.length) {
+  if (resolveAccessoryKind(styleController.accessoryIndex) !== 'spray') {
     return
   }
 
@@ -3080,6 +3095,7 @@ function renderCurrentSceneFrame(options: {
       beachBalls: beachBallArray,
       bubbles: bubbleArray,
       foam: foamArray,
+      smokePuff: smokePuffArray,
       graffiti: graffitiArray,
       room: array,
       smoke: smokeArray,
@@ -3117,6 +3133,7 @@ function renderCurrentSceneFrame(options: {
     beachBallPoints,
     bubblePoints,
     foamPoints,
+    smokePuffPoints,
     graffitiPoints: options.inLoft ? emptyPoints : graffitiPoints,
     graffitiTexture,
     post: {
@@ -3246,6 +3263,10 @@ const draw = (stamp: number) => {
     emitFoam()
   }
   foamSystem.update(delta, inLoft ? loftFloorAt : mainFloorAt)
+  if (introHidden && resolveAccessoryKind(styleController.accessoryIndex) === 'cigarette') {
+    emitCigaretteSmoke(stamp)
+  }
+  smokeSystem.update(delta)
   const hits = inLoft ? [] : hitBeachBalls(beachBalls, characterPosition)
 
   for (const id of hits) {
@@ -3351,6 +3372,7 @@ const draw = (stamp: number) => {
   updateBeachBallBuffer()
   updateBubbleBuffer()
   updateFoamBuffer()
+  updateSmokeBuffer()
   if (!introHidden) {
     updateIntro()
   }
@@ -3419,6 +3441,43 @@ function updateFoamBuffer() {
   foamPoints = vertexWriterData(foamWriter)
   gl.bindBuffer(gl.ARRAY_BUFFER, foamBuffer)
   gl.bufferData(gl.ARRAY_BUFFER, foamPoints, gl.DYNAMIC_DRAW)
+}
+
+function emitCigaretteSmoke(stamp: number) {
+  const time = stamp * 0.001
+  const turn = localCharacter.turn
+  const forwardX = Math.sin(turn)
+  const forwardZ = Math.cos(turn)
+  const lift = cigaretteLift(time)
+  const exhale = cigaretteExhale(time)
+
+  smokeForward[0] = forwardX
+  smokeForward[1] = 0
+  smokeForward[2] = forwardZ
+
+  if (stamp >= nextSmokeAt) {
+    nextSmokeAt = stamp + smokeInterval
+    smokeTip[0] = characterPosition[0] + forwardX * 0.22
+    smokeTip[1] = characterPosition[1] + 1 + lift * 0.5
+    smokeTip[2] = characterPosition[2] + forwardZ * 0.22
+    smokeSystem.emit(smokeTip, smokeForward, 1, false)
+  }
+
+  if (exhale > 0 && stamp >= nextSmokeExhaleAt) {
+    nextSmokeExhaleAt = stamp + smokeExhaleInterval
+    smokeMouth[0] = characterPosition[0] + forwardX * 0.18
+    smokeMouth[1] = characterPosition[1] + 1.5
+    smokeMouth[2] = characterPosition[2] + forwardZ * 0.18
+    smokeSystem.emit(smokeMouth, smokeForward, 1 + Math.floor(exhale * 3), true)
+  }
+}
+
+function updateSmokeBuffer() {
+  resetVertexWriter(smokeWriter)
+  writeSmokeGeometry(smokeWriter, smokeSystem.puffs)
+  smokePuffPoints = vertexWriterData(smokeWriter)
+  gl.bindBuffer(gl.ARRAY_BUFFER, smokePuffBuffer)
+  gl.bufferData(gl.ARRAY_BUFFER, smokePuffPoints, gl.DYNAMIC_DRAW)
 }
 
 function updateBeachBallBuffer() {

--- a/src/club-app.ts
+++ b/src/club-app.ts
@@ -3445,8 +3445,8 @@ function emitPlayerParticles(
     // Heights measured from the actual rig: mouth just below the head joint,
     // hand hanging around mid-body. The wisp tracks the cigarette from the hand
     // up to the mouth as it is raised for a drag.
-    const mouthHeight = characterRenderSystem.headHeight - 0.1
-    const handHeight = characterRenderSystem.headHeight * 0.5
+    const mouthHeight = characterRenderSystem.headHeight
+    const handHeight = characterRenderSystem.headHeight * 0.55
 
     smokeForward[0] = forwardX
     smokeForward[1] = 0

--- a/src/club-renderer.ts
+++ b/src/club-renderer.ts
@@ -64,6 +64,7 @@ export function renderClubFrame(options: {
     post: WebGLVertexArrayObject
     beachBalls: WebGLVertexArrayObject
     bubbles: WebGLVertexArrayObject
+    foam: WebGLVertexArrayObject
     graffiti: WebGLVertexArrayObject
     room: WebGLVertexArrayObject
     smoke: WebGLVertexArrayObject
@@ -100,6 +101,7 @@ export function renderClubFrame(options: {
   points: Float32Array
   beachBallPoints: Float32Array
   bubblePoints: Float32Array
+  foamPoints: Float32Array
   graffitiPoints: Float32Array
   graffitiTexture: WebGLTexture
   post: {
@@ -168,6 +170,7 @@ export function renderClubFrame(options: {
   gl.drawArrays(gl.TRIANGLES, 0, options.points.length / options.vertexSize)
   drawBeachBalls(options)
   drawBubbles(options)
+  drawFoam(options)
   gl.disable(gl.POLYGON_OFFSET_FILL)
   gl.depthFunc(gl.LEQUAL)
   gl.depthMask(false)
@@ -242,6 +245,7 @@ export function renderClubFrame(options: {
   gl.drawArrays(gl.TRIANGLES, 0, options.points.length / options.vertexSize)
   drawBeachBalls(options)
   drawBubbles(options)
+  drawFoam(options)
   gl.disable(gl.POLYGON_OFFSET_FILL)
   gl.depthFunc(gl.LEQUAL)
   drawGraffiti(options)
@@ -344,6 +348,15 @@ function drawBubbles(options: Parameters<typeof renderClubFrame>[0]) {
 
   options.gl.bindVertexArray(options.arrays.bubbles)
   options.gl.drawArrays(options.gl.TRIANGLES, 0, options.bubblePoints.length / options.vertexSize)
+}
+
+function drawFoam(options: Parameters<typeof renderClubFrame>[0]) {
+  if (options.foamPoints.length === 0) {
+    return
+  }
+
+  options.gl.bindVertexArray(options.arrays.foam)
+  options.gl.drawArrays(options.gl.TRIANGLES, 0, options.foamPoints.length / options.vertexSize)
 }
 
 function drawGraffiti(options: Parameters<typeof renderClubFrame>[0]) {

--- a/src/club-renderer.ts
+++ b/src/club-renderer.ts
@@ -63,6 +63,7 @@ export function renderClubFrame(options: {
     light: WebGLVertexArrayObject
     post: WebGLVertexArrayObject
     beachBalls: WebGLVertexArrayObject
+    bubbles: WebGLVertexArrayObject
     graffiti: WebGLVertexArrayObject
     room: WebGLVertexArrayObject
     smoke: WebGLVertexArrayObject
@@ -98,6 +99,7 @@ export function renderClubFrame(options: {
   doorCoverVisible: boolean
   points: Float32Array
   beachBallPoints: Float32Array
+  bubblePoints: Float32Array
   graffitiPoints: Float32Array
   graffitiTexture: WebGLTexture
   post: {
@@ -165,6 +167,7 @@ export function renderClubFrame(options: {
   gl.polygonOffset(1, 1)
   gl.drawArrays(gl.TRIANGLES, 0, options.points.length / options.vertexSize)
   drawBeachBalls(options)
+  drawBubbles(options)
   gl.disable(gl.POLYGON_OFFSET_FILL)
   gl.depthFunc(gl.LEQUAL)
   gl.depthMask(false)
@@ -238,6 +241,7 @@ export function renderClubFrame(options: {
   gl.polygonOffset(1, 1)
   gl.drawArrays(gl.TRIANGLES, 0, options.points.length / options.vertexSize)
   drawBeachBalls(options)
+  drawBubbles(options)
   gl.disable(gl.POLYGON_OFFSET_FILL)
   gl.depthFunc(gl.LEQUAL)
   drawGraffiti(options)
@@ -331,6 +335,15 @@ function drawBeachBalls(options: Parameters<typeof renderClubFrame>[0]) {
 
   options.gl.bindVertexArray(options.arrays.beachBalls)
   options.gl.drawArrays(options.gl.TRIANGLES, 0, options.beachBallPoints.length / options.vertexSize)
+}
+
+function drawBubbles(options: Parameters<typeof renderClubFrame>[0]) {
+  if (options.bubblePoints.length === 0) {
+    return
+  }
+
+  options.gl.bindVertexArray(options.arrays.bubbles)
+  options.gl.drawArrays(options.gl.TRIANGLES, 0, options.bubblePoints.length / options.vertexSize)
 }
 
 function drawGraffiti(options: Parameters<typeof renderClubFrame>[0]) {

--- a/src/club-renderer.ts
+++ b/src/club-renderer.ts
@@ -65,6 +65,7 @@ export function renderClubFrame(options: {
     beachBalls: WebGLVertexArrayObject
     bubbles: WebGLVertexArrayObject
     foam: WebGLVertexArrayObject
+    smokePuff: WebGLVertexArrayObject
     graffiti: WebGLVertexArrayObject
     room: WebGLVertexArrayObject
     smoke: WebGLVertexArrayObject
@@ -102,6 +103,7 @@ export function renderClubFrame(options: {
   beachBallPoints: Float32Array
   bubblePoints: Float32Array
   foamPoints: Float32Array
+  smokePuffPoints: Float32Array
   graffitiPoints: Float32Array
   graffitiTexture: WebGLTexture
   post: {
@@ -171,6 +173,7 @@ export function renderClubFrame(options: {
   drawBeachBalls(options)
   drawBubbles(options)
   drawFoam(options)
+  drawSmokePuff(options)
   gl.disable(gl.POLYGON_OFFSET_FILL)
   gl.depthFunc(gl.LEQUAL)
   gl.depthMask(false)
@@ -246,6 +249,7 @@ export function renderClubFrame(options: {
   drawBeachBalls(options)
   drawBubbles(options)
   drawFoam(options)
+  drawSmokePuff(options)
   gl.disable(gl.POLYGON_OFFSET_FILL)
   gl.depthFunc(gl.LEQUAL)
   drawGraffiti(options)
@@ -357,6 +361,15 @@ function drawFoam(options: Parameters<typeof renderClubFrame>[0]) {
 
   options.gl.bindVertexArray(options.arrays.foam)
   options.gl.drawArrays(options.gl.TRIANGLES, 0, options.foamPoints.length / options.vertexSize)
+}
+
+function drawSmokePuff(options: Parameters<typeof renderClubFrame>[0]) {
+  if (options.smokePuffPoints.length === 0) {
+    return
+  }
+
+  options.gl.bindVertexArray(options.arrays.smokePuff)
+  options.gl.drawArrays(options.gl.TRIANGLES, 0, options.smokePuffPoints.length / options.vertexSize)
 }
 
 function drawGraffiti(options: Parameters<typeof renderClubFrame>[0]) {

--- a/src/dom-elements.ts
+++ b/src/dom-elements.ts
@@ -17,6 +17,7 @@ export function getDomElements() {
   const breakdanceButton = document.createElement('button')
   const waveButton = document.createElement('button')
   const bubbleButton = document.createElement('button')
+  const foamButton = document.createElement('button')
   const roomsButton = document.createElement('button')
   const supportLink = document.createElement('a')
   const intro = document.createElement('div')
@@ -87,6 +88,10 @@ export function getDomElements() {
   bubbleButton.type = 'button'
   bubbleButton.textContent = '🫧'
   bubbleButton.setAttribute('aria-label', 'bubbles')
+  foamButton.id = 'foam-button'
+  foamButton.type = 'button'
+  foamButton.textContent = '🧼'
+  foamButton.setAttribute('aria-label', 'foam')
   roomsButton.id = 'rooms-button'
   roomsButton.type = 'button'
   roomsButton.textContent = '🏘️'
@@ -135,7 +140,7 @@ export function getDomElements() {
   introGithub.append(introGithubIcon)
   intro.append(introEffect, introPanel, introGithub)
   document.body.prepend(canvas, djVideo, photoWall, chatForm, chatBubble, onlineIndicator, reactionButtons,
-    waveButton, bubbleButton, breakdanceButton, photoButton, roomsButton, supportLink, intro)
+    waveButton, bubbleButton, foamButton, breakdanceButton, photoButton, roomsButton, supportLink, intro)
 
   return {
     canvas,
@@ -154,6 +159,7 @@ export function getDomElements() {
     breakdanceButton,
     waveButton,
     bubbleButton,
+    foamButton,
     photoButton,
     roomsButton,
     supportLink,

--- a/src/dom-elements.ts
+++ b/src/dom-elements.ts
@@ -16,6 +16,7 @@ export function getDomElements() {
   const photoButton = document.createElement('button')
   const breakdanceButton = document.createElement('button')
   const waveButton = document.createElement('button')
+  const bubbleButton = document.createElement('button')
   const roomsButton = document.createElement('button')
   const supportLink = document.createElement('a')
   const intro = document.createElement('div')
@@ -82,6 +83,10 @@ export function getDomElements() {
   waveButton.type = 'button'
   waveButton.textContent = '🙌'
   waveButton.setAttribute('aria-label', 'wave')
+  bubbleButton.id = 'bubble-button'
+  bubbleButton.type = 'button'
+  bubbleButton.textContent = '🫧'
+  bubbleButton.setAttribute('aria-label', 'bubbles')
   roomsButton.id = 'rooms-button'
   roomsButton.type = 'button'
   roomsButton.textContent = '🏘️'
@@ -130,7 +135,7 @@ export function getDomElements() {
   introGithub.append(introGithubIcon)
   intro.append(introEffect, introPanel, introGithub)
   document.body.prepend(canvas, djVideo, photoWall, chatForm, chatBubble, onlineIndicator, reactionButtons,
-    waveButton, breakdanceButton, photoButton, roomsButton, supportLink, intro)
+    waveButton, bubbleButton, breakdanceButton, photoButton, roomsButton, supportLink, intro)
 
   return {
     canvas,
@@ -148,6 +153,7 @@ export function getDomElements() {
     reactionButtons,
     breakdanceButton,
     waveButton,
+    bubbleButton,
     photoButton,
     roomsButton,
     supportLink,

--- a/src/foam.ts
+++ b/src/foam.ts
@@ -1,0 +1,105 @@
+import type { VertexWriter } from './character-geometry.ts'
+import { createUnitSphere, reserveSphereFloats, writeSphere } from './sphere-geometry.ts'
+import type { Vec3 } from './types.ts'
+
+export type FoamBlob = {
+  position: Vec3
+  velocity: Vec3
+  baseRadius: number
+  radius: number
+  life: number
+}
+
+const gravity = 9.5
+const forwardSpeed = 4.6
+const upSpeed = 2.2
+const spread = 2.4
+const settleDamp = 7
+const minRadius = 0.06
+const maxRadius = 0.15
+const minLife = 4
+const maxLife = 7
+const fadeTime = 1.6
+const foamGlow = 0.8
+const foamColor: Vec3 = [0.95, 0.97, 1]
+const unitSphere = createUnitSphere(6, 10)
+
+export type FloorAt = (x: number, y: number, z: number) => number
+
+function createFoam(): FoamBlob {
+  return {
+    position: [0, 0, 0],
+    velocity: [0, 0, 0],
+    baseRadius: 0,
+    radius: 0,
+    life: 0,
+  }
+}
+
+export function createFoamSystem() {
+  const blobs: FoamBlob[] = []
+  const pool: FoamBlob[] = []
+
+  function burst(origin: Vec3, forward: Vec3, count: number) {
+    for (let i = 0; i < count; i++) {
+      const blob = pool.pop() ?? createFoam()
+
+      blob.position[0] = origin[0] + (Math.random() - 0.5) * 0.2
+      blob.position[1] = origin[1] + (Math.random() - 0.5) * 0.2
+      blob.position[2] = origin[2] + (Math.random() - 0.5) * 0.2
+      blob.velocity[0] = forward[0] * forwardSpeed + (Math.random() - 0.5) * spread
+      blob.velocity[1] = upSpeed + Math.random() * upSpeed
+      blob.velocity[2] = forward[2] * forwardSpeed + (Math.random() - 0.5) * spread
+      blob.baseRadius = minRadius + Math.random() * (maxRadius - minRadius)
+      blob.radius = blob.baseRadius
+      blob.life = minLife + Math.random() * (maxLife - minLife)
+      blobs.push(blob)
+    }
+  }
+
+  function update(delta: number, floorAt: FloorAt) {
+    const damp = Math.exp(-settleDamp * delta)
+
+    for (let i = blobs.length - 1; i >= 0; i--) {
+      const blob = blobs[i]!
+
+      blob.life -= delta
+      if (blob.life <= 0) {
+        const last = blobs.pop()!
+
+        if (i < blobs.length) {
+          blobs[i] = last
+        }
+        pool.push(blob)
+        continue
+      }
+
+      blob.velocity[1] -= gravity * delta
+      blob.position[0] += blob.velocity[0] * delta
+      blob.position[1] += blob.velocity[1] * delta
+      blob.position[2] += blob.velocity[2] * delta
+
+      const floor = floorAt(blob.position[0], blob.position[1], blob.position[2]) + blob.baseRadius
+
+      if (blob.position[1] < floor) {
+        blob.position[1] = floor
+        blob.velocity[1] = 0
+        blob.velocity[0] *= damp
+        blob.velocity[2] *= damp
+      }
+
+      blob.radius = blob.baseRadius * Math.min(1, blob.life / fadeTime)
+    }
+  }
+
+  return { blobs, burst, update }
+}
+
+export function writeFoamGeometry(target: VertexWriter, blobs: FoamBlob[]) {
+  reserveSphereFloats(target, unitSphere, blobs.length)
+
+  for (const blob of blobs) {
+    writeSphere(target, unitSphere, blob.position[0], blob.position[1], blob.position[2], blob.radius, foamColor,
+      foamGlow)
+  }
+}

--- a/src/input.ts
+++ b/src/input.ts
@@ -31,6 +31,8 @@ export function bindKeyboardInput(options: {
   stopWave: () => void
   startBubbles: () => void
   stopBubbles: () => void
+  startFoam: () => void
+  stopFoam: () => void
   startBreakdance: () => void
   cycleHair: (direction: number) => void
   cycleHairColor: (direction: number) => void
@@ -83,6 +85,11 @@ export function bindKeyboardInput(options: {
 
     if (key === 'c') {
       options.startBubbles()
+      return
+    }
+
+    if (key === 'n') {
+      options.startFoam()
       return
     }
 
@@ -179,6 +186,11 @@ export function bindKeyboardInput(options: {
 
     if (key === 'c') {
       options.stopBubbles()
+      return
+    }
+
+    if (key === 'n') {
+      options.stopFoam()
       return
     }
 

--- a/src/input.ts
+++ b/src/input.ts
@@ -29,6 +29,8 @@ export function bindKeyboardInput(options: {
   stopJumping: () => void
   startWave: () => void
   stopWave: () => void
+  startBubbles: () => void
+  stopBubbles: () => void
   startBreakdance: () => void
   cycleHair: (direction: number) => void
   cycleHairColor: (direction: number) => void
@@ -76,6 +78,11 @@ export function bindKeyboardInput(options: {
 
     if (key === 'v') {
       options.startWave()
+      return
+    }
+
+    if (key === 'c') {
+      options.startBubbles()
       return
     }
 
@@ -167,6 +174,11 @@ export function bindKeyboardInput(options: {
 
     if (key === 'v') {
       options.stopWave()
+      return
+    }
+
+    if (key === 'c') {
+      options.stopBubbles()
       return
     }
 

--- a/src/multiplayer.ts
+++ b/src/multiplayer.ts
@@ -2,12 +2,16 @@ import { characterFloor } from './character-data.ts'
 import { resolvePlayerStyle } from './character-style.ts'
 import { lengthSq } from './math.ts'
 import {
+  ACTION_BUBBLING,
+  ACTION_FOAMING,
+  ACTIONS,
   angleToProtocol,
   BEACH_BALLS,
   decodeBeachBalls,
   decodeGraffiti,
   decodeKeys,
   decodeLeave,
+  decodeServerActions,
   decodeModerationMessage,
   decodeOnline,
   decodeRoomState,
@@ -20,6 +24,7 @@ import {
   encodeAdminMessage,
   encodeBeachBalls,
   encodeClientMessage,
+  encodeClientActions,
   encodeClientMotion,
   encodeClientNickname,
   encodeGraffiti,
@@ -68,6 +73,7 @@ export function createMultiplayer(options: {
   localInput: Vec3
   localMode: () => CharacterMode
   localIdleClipIndex: () => number
+  localActions: () => number
   localNickname: () => string
   localStyle: () => {
     topStyleIndex: number
@@ -107,6 +113,7 @@ export function createMultiplayer(options: {
   let lastAngle = -1
   let lastMode = -1
   let lastHeight = Infinity
+  let lastActions = -1
   let socket = connect()
 
   function connect() {
@@ -119,6 +126,7 @@ export function createMultiplayer(options: {
       heartbeat = setInterval(() => send(encodeHeartbeat()), heartbeatInterval)
       videoProgress = setInterval(() => sendVideoProgress(), videoProgressInterval)
       room = options.initialRoom
+      lastActions = -1
       sendMotion()
       sendNickname()
       send(encodeRoomChange(room))
@@ -262,6 +270,18 @@ export function createMultiplayer(options: {
       return
     }
 
+    if (type === ACTIONS) {
+      const packet = decodeServerActions(view)
+      const player = players.get(packet.id)
+
+      if (player) {
+        player.bubbling = (packet.actions & ACTION_BUBBLING) !== 0
+        player.foaming = (packet.actions & ACTION_FOAMING) !== 0
+      }
+
+      return
+    }
+
     if (type === MODERATION) {
       const message = decodeModerationMessage(view)
 
@@ -362,6 +382,14 @@ export function createMultiplayer(options: {
       queue(encodeAdminMessage({ pass, command, id }))
     },
     sendMotion,
+    sendActionsIfChanged() {
+      const actions = options.localActions()
+
+      if (actions !== lastActions) {
+        lastActions = actions
+        send(encodeClientActions(actions))
+      }
+    },
     sendVideoEnded,
     sendVideoProgress,
     sendVideoPlaylist,

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -20,12 +20,16 @@ export const VIDEO_PLAYLIST = 17
 export const VIDEO_ENDED = 18
 export const VIDEO_PLAYLIST_REQUEST = 19
 export const NICKNAME = 20
+export const ACTIONS = 21
+
+export const ACTION_BUBBLING = 1
+export const ACTION_FOAMING = 2
 
 export const roomCount = 3
 export const messageMaxLength = 120
 export const nicknameMaxLength = 32
 export const positionScale = 100
-export const protocolVersion = 38
+export const protocolVersion = 39
 
 const textEncoder = new TextEncoder()
 const textDecoder = new TextDecoder()
@@ -117,6 +121,11 @@ export type BeachBallPacket = {
 
 export type GraffitiPacket = {
   splats: GraffitiSplat[]
+}
+
+export type ActionsPacket = {
+  id: number
+  actions: number
 }
 
 export type AdminPacket = {
@@ -690,6 +699,42 @@ export function decodeServerNickname(view: DataView): NicknamePacket {
   return {
     id: view.getUint16(1),
     text: textDecoder.decode(new Uint8Array(view.buffer, view.byteOffset + 5, length)),
+  }
+}
+
+export function encodeClientActions(actions: number) {
+  const data = new ArrayBuffer(2)
+  const view = new DataView(data)
+
+  view.setUint8(0, ACTIONS)
+  view.setUint8(1, actions)
+
+  return data
+}
+
+export function decodeClientActions(view: DataView) {
+  expectSize(view, 2)
+
+  return view.getUint8(1)
+}
+
+export function encodeServerActions(packet: ActionsPacket) {
+  const data = new ArrayBuffer(4)
+  const view = new DataView(data)
+
+  view.setUint8(0, ACTIONS)
+  view.setUint16(1, packet.id)
+  view.setUint8(3, packet.actions)
+
+  return data
+}
+
+export function decodeServerActions(view: DataView): ActionsPacket {
+  expectSize(view, 4)
+
+  return {
+    id: view.getUint16(1),
+    actions: view.getUint8(3),
   }
 }
 

--- a/src/smoke-puff.ts
+++ b/src/smoke-puff.ts
@@ -11,15 +11,16 @@ export type SmokePuff = {
   maxLife: number
 }
 
-const rise = 0.45
-const drift = 0.12
+const rise = 0.32
+const riseDamp = 0.6
+const drift = 0.1
 const damp = 1.4
 const growth = 1.6
 const fadeFraction = 0.4
 const wispRadius = 0.035
 const puffRadius = 0.07
-const minLife = 2.4
-const maxLife = 4
+const minLife = 1.6
+const maxLife = 2.8
 const puffGlow = 0.18
 const smokeColor: Vec3 = [0.72, 0.72, 0.76]
 const unitSphere = createUnitSphere(6, 8)
@@ -48,7 +49,7 @@ export function createSmokeSystem() {
       puff.position[1] = origin[1] + (Math.random() - 0.5) * 0.06
       puff.position[2] = origin[2] + (Math.random() - 0.5) * 0.06
       puff.velocity[0] = forward[0] * push + (Math.random() - 0.5) * drift
-      puff.velocity[1] = rise + Math.random() * rise
+      puff.velocity[1] = rise * (0.7 + Math.random() * 0.6)
       puff.velocity[2] = forward[2] * push + (Math.random() - 0.5) * drift
       puff.baseRadius = exhale ? puffRadius : wispRadius
       puff.radius = puff.baseRadius
@@ -60,6 +61,7 @@ export function createSmokeSystem() {
 
   function update(delta: number) {
     const horizontalDamp = Math.exp(-damp * delta)
+    const verticalDamp = Math.exp(-riseDamp * delta)
 
     for (let i = puffs.length - 1; i >= 0; i--) {
       const puff = puffs[i]!
@@ -76,6 +78,7 @@ export function createSmokeSystem() {
       }
 
       puff.velocity[0] *= horizontalDamp
+      puff.velocity[1] *= verticalDamp
       puff.velocity[2] *= horizontalDamp
       puff.position[0] += puff.velocity[0] * delta
       puff.position[1] += puff.velocity[1] * delta

--- a/src/smoke-puff.ts
+++ b/src/smoke-puff.ts
@@ -1,0 +1,101 @@
+import type { VertexWriter } from './character-geometry.ts'
+import { createUnitSphere, reserveSphereFloats, writeSphere } from './sphere-geometry.ts'
+import type { Vec3 } from './types.ts'
+
+export type SmokePuff = {
+  position: Vec3
+  velocity: Vec3
+  baseRadius: number
+  radius: number
+  life: number
+  maxLife: number
+}
+
+const rise = 0.45
+const drift = 0.12
+const damp = 1.4
+const growth = 1.6
+const fadeFraction = 0.4
+const wispRadius = 0.035
+const puffRadius = 0.07
+const minLife = 2.4
+const maxLife = 4
+const puffGlow = 0.18
+const smokeColor: Vec3 = [0.72, 0.72, 0.76]
+const unitSphere = createUnitSphere(6, 8)
+
+function createPuff(): SmokePuff {
+  return {
+    position: [0, 0, 0],
+    velocity: [0, 0, 0],
+    baseRadius: 0,
+    radius: 0,
+    life: 0,
+    maxLife: 0,
+  }
+}
+
+export function createSmokeSystem() {
+  const puffs: SmokePuff[] = []
+  const pool: SmokePuff[] = []
+
+  function emit(origin: Vec3, forward: Vec3, count: number, exhale: boolean) {
+    for (let i = 0; i < count; i++) {
+      const puff = pool.pop() ?? createPuff()
+      const push = exhale ? 0.9 : 0.2
+
+      puff.position[0] = origin[0] + (Math.random() - 0.5) * 0.06
+      puff.position[1] = origin[1] + (Math.random() - 0.5) * 0.06
+      puff.position[2] = origin[2] + (Math.random() - 0.5) * 0.06
+      puff.velocity[0] = forward[0] * push + (Math.random() - 0.5) * drift
+      puff.velocity[1] = rise + Math.random() * rise
+      puff.velocity[2] = forward[2] * push + (Math.random() - 0.5) * drift
+      puff.baseRadius = exhale ? puffRadius : wispRadius
+      puff.radius = puff.baseRadius
+      puff.maxLife = minLife + Math.random() * (maxLife - minLife)
+      puff.life = puff.maxLife
+      puffs.push(puff)
+    }
+  }
+
+  function update(delta: number) {
+    const horizontalDamp = Math.exp(-damp * delta)
+
+    for (let i = puffs.length - 1; i >= 0; i--) {
+      const puff = puffs[i]!
+
+      puff.life -= delta
+      if (puff.life <= 0) {
+        const last = puffs.pop()!
+
+        if (i < puffs.length) {
+          puffs[i] = last
+        }
+        pool.push(puff)
+        continue
+      }
+
+      puff.velocity[0] *= horizontalDamp
+      puff.velocity[2] *= horizontalDamp
+      puff.position[0] += puff.velocity[0] * delta
+      puff.position[1] += puff.velocity[1] * delta
+      puff.position[2] += puff.velocity[2] * delta
+
+      const age = 1 - puff.life / puff.maxLife
+      const fade = Math.min(1, puff.life / (puff.maxLife * fadeFraction))
+
+      puff.radius = puff.baseRadius * (1 + growth * age) * fade
+    }
+  }
+
+  return { puffs, emit, update }
+}
+
+export function writeSmokeGeometry(target: VertexWriter, puffs: SmokePuff[]) {
+  reserveSphereFloats(target, unitSphere, puffs.length)
+
+  for (const puff of puffs) {
+    writeSphere(target, unitSphere, puff.position[0], puff.position[1], puff.position[2], puff.radius, smokeColor,
+      puffGlow)
+  }
+}

--- a/src/sphere-geometry.ts
+++ b/src/sphere-geometry.ts
@@ -1,0 +1,71 @@
+import { reserveFloats } from './character-geometry.ts'
+import type { VertexWriter } from './character-geometry.ts'
+import type { Vec3 } from './types.ts'
+
+export function createUnitSphere(rows: number, columns: number) {
+  const vertices: number[] = []
+
+  for (let y = 0; y < rows; y++) {
+    const top = -Math.PI / 2 + Math.PI * y / rows
+    const bottom = -Math.PI / 2 + Math.PI * (y + 1) / rows
+
+    for (let x = 0; x < columns; x++) {
+      const left = Math.PI * 2 * x / columns
+      const right = Math.PI * 2 * (x + 1) / columns
+
+      addUnitQuad(vertices, top, bottom, left, right)
+    }
+  }
+
+  return new Float32Array(vertices)
+}
+
+export function reserveSphereFloats(target: VertexWriter, unit: Float32Array, count: number) {
+  reserveFloats(target, count * unit.length / 3 * 11)
+}
+
+export function writeSphere(
+  target: VertexWriter,
+  unit: Float32Array,
+  centerX: number,
+  centerY: number,
+  centerZ: number,
+  radius: number,
+  color: Vec3,
+  glow: number,
+) {
+  const data = target.data
+  let offset = target.length
+
+  for (let i = 0; i < unit.length; i += 3) {
+    data[offset] = centerX + unit[i]! * radius
+    data[offset + 1] = centerY + unit[i + 1]! * radius
+    data[offset + 2] = centerZ + unit[i + 2]! * radius
+    data[offset + 3] = color[0]
+    data[offset + 4] = color[1]
+    data[offset + 5] = color[2]
+    data[offset + 6] = glow
+    data[offset + 7] = 0
+    data[offset + 8] = 0
+    data[offset + 9] = 0
+    data[offset + 10] = 0
+    offset += 11
+  }
+
+  target.length = offset
+}
+
+function addUnitQuad(target: number[], top: number, bottom: number, left: number, right: number) {
+  addUnitPoint(target, top, left)
+  addUnitPoint(target, top, right)
+  addUnitPoint(target, bottom, right)
+  addUnitPoint(target, top, left)
+  addUnitPoint(target, bottom, right)
+  addUnitPoint(target, bottom, left)
+}
+
+function addUnitPoint(target: number[], vertical: number, horizontal: number) {
+  const radius = Math.cos(vertical)
+
+  target.push(Math.cos(horizontal) * radius, Math.sin(vertical), Math.sin(horizontal) * radius)
+}

--- a/src/style.css
+++ b/src/style.css
@@ -682,6 +682,7 @@ html[data-touch-controls="true"] #reaction-buttons[data-hidden="true"] {
 #breakdance-button,
 #wave-button,
 #bubble-button,
+#foam-button,
 #photo-button,
 #rooms-button,
 #support-link {
@@ -702,6 +703,7 @@ html[data-touch-controls="true"] #reaction-buttons[data-hidden="true"] {
 #breakdance-button,
 #wave-button,
 #bubble-button,
+#foam-button,
 #photo-button {
   right: var(--action-right);
   border: 0;
@@ -721,6 +723,10 @@ html[data-touch-controls="true"] #reaction-buttons[data-hidden="true"] {
 
 #bubble-button {
   bottom: calc(12px + var(--app-bottom) + (var(--action-size) + var(--action-gap)) * 5);
+}
+
+#foam-button {
+  bottom: calc(12px + var(--app-bottom) + (var(--action-size) + var(--action-gap)) * 6);
 }
 
 #photo-button {
@@ -750,6 +756,7 @@ html[data-touch-controls="true"] #reaction-buttons[data-hidden="true"] {
 #breakdance-button[data-hidden="true"],
 #wave-button[data-hidden="true"],
 #bubble-button[data-hidden="true"],
+#foam-button[data-hidden="true"],
 #photo-button[data-hidden="true"],
 #rooms-button[data-hidden="true"],
 #support-link[data-hidden="true"] {
@@ -759,6 +766,7 @@ html[data-touch-controls="true"] #reaction-buttons[data-hidden="true"] {
 html[data-touch-controls="true"] #breakdance-button[data-hidden="true"],
 html[data-touch-controls="true"] #wave-button[data-hidden="true"],
 html[data-touch-controls="true"] #bubble-button[data-hidden="true"],
+html[data-touch-controls="true"] #foam-button[data-hidden="true"],
 html[data-touch-controls="true"] #photo-button[data-hidden="true"],
 html[data-touch-controls="true"] #rooms-button[data-hidden="true"],
 html[data-touch-controls="true"] #support-link[data-hidden="true"] {
@@ -773,6 +781,7 @@ html[data-touch-controls="true"] body[data-intro-visible="true"] #online-indicat
 html[data-touch-controls="true"] body[data-intro-visible="true"] #breakdance-button,
 html[data-touch-controls="true"] body[data-intro-visible="true"] #wave-button,
 html[data-touch-controls="true"] body[data-intro-visible="true"] #bubble-button,
+html[data-touch-controls="true"] body[data-intro-visible="true"] #foam-button,
 html[data-touch-controls="true"] body[data-intro-visible="true"] #photo-button,
 html[data-touch-controls="true"] body[data-intro-visible="true"] #rooms-button {
   display: none;

--- a/src/style.css
+++ b/src/style.css
@@ -681,6 +681,7 @@ html[data-touch-controls="true"] #reaction-buttons[data-hidden="true"] {
 
 #breakdance-button,
 #wave-button,
+#bubble-button,
 #photo-button,
 #rooms-button,
 #support-link {
@@ -700,6 +701,7 @@ html[data-touch-controls="true"] #reaction-buttons[data-hidden="true"] {
 
 #breakdance-button,
 #wave-button,
+#bubble-button,
 #photo-button {
   right: var(--action-right);
   border: 0;
@@ -715,6 +717,10 @@ html[data-touch-controls="true"] #reaction-buttons[data-hidden="true"] {
 
 #wave-button {
   bottom: calc(12px + var(--app-bottom) + (var(--action-size) + var(--action-gap)) * 4);
+}
+
+#bubble-button {
+  bottom: calc(12px + var(--app-bottom) + (var(--action-size) + var(--action-gap)) * 5);
 }
 
 #photo-button {
@@ -743,6 +749,7 @@ html[data-touch-controls="true"] #reaction-buttons[data-hidden="true"] {
 
 #breakdance-button[data-hidden="true"],
 #wave-button[data-hidden="true"],
+#bubble-button[data-hidden="true"],
 #photo-button[data-hidden="true"],
 #rooms-button[data-hidden="true"],
 #support-link[data-hidden="true"] {
@@ -751,6 +758,7 @@ html[data-touch-controls="true"] #reaction-buttons[data-hidden="true"] {
 
 html[data-touch-controls="true"] #breakdance-button[data-hidden="true"],
 html[data-touch-controls="true"] #wave-button[data-hidden="true"],
+html[data-touch-controls="true"] #bubble-button[data-hidden="true"],
 html[data-touch-controls="true"] #photo-button[data-hidden="true"],
 html[data-touch-controls="true"] #rooms-button[data-hidden="true"],
 html[data-touch-controls="true"] #support-link[data-hidden="true"] {
@@ -764,6 +772,7 @@ html[data-touch-controls="true"] body[data-intro-visible="true"] #chat-form,
 html[data-touch-controls="true"] body[data-intro-visible="true"] #online-indicator,
 html[data-touch-controls="true"] body[data-intro-visible="true"] #breakdance-button,
 html[data-touch-controls="true"] body[data-intro-visible="true"] #wave-button,
+html[data-touch-controls="true"] body[data-intro-visible="true"] #bubble-button,
 html[data-touch-controls="true"] body[data-intro-visible="true"] #photo-button,
 html[data-touch-controls="true"] body[data-intro-visible="true"] #rooms-button {
   display: none;

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,6 +212,8 @@ export type Player = {
   style: PlayerStyle
   resolvedStyle: ResolvedPlayerStyle
   seed: number
+  bubbling?: boolean
+  foaming?: boolean
 }
 
 export type BeachBall = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,7 +176,7 @@ export type ResolvedPlayerStyle = {
   hairColor: Vec3
   skin: Vec3
   accessory?: Vec3
-  accessoryKind?: 'glowstick' | 'spray'
+  accessoryKind?: 'glowstick' | 'spray' | 'cigarette'
 }
 
 export type PlayerDestination = {


### PR DESCRIPTION
Adds three player-driven particle effects, all built on a shared sphere-geometry core extracted from the existing beach balls, and all synced in multiplayer.

## Features

**🫧 Bubble gun** — hold **C** or the bubble button to spray glowing, drifting soap bubbles that wobble and pop.

**🧼 Foam cannon** — hold **N** or the foam button to fire dense bursts of white spheres that arc out, fall under gravity, pile up on the floor (main + loft aware), and slowly shrink away.

**🚬 Smokeable cigarette** — equip via the accessory keys (E/R) like glowsticks/spray. The character periodically raises it from the hand to the mouth to take a drag (the forearm + hand follow), then exhales a plume; a thin smoke wisp rises from the lit ember continuously. Smoke origin is anchored to the measured head-joint height so it sits at the mouth regardless of rig scale.

## Architecture

- New `sphere-geometry.ts` — shared unit-sphere builder + `writeSphere`, extracted from `beach-balls.ts` (which now reuses it, no behaviour change).
- New particle pools: `bubbles.ts`, `foam.ts`, `smoke-puff.ts` — allocation-free pools recycling through a free list, rendered via the room program's glow channel (bloom does the shine).
- `cigarette.ts` holds the smoking-cycle timing so the visual drag and the smoke emission stay in lockstep.

## Multiplayer

- One `emitPlayerParticles(...)` runs for the local player and every remote player from their own position, driven by synced state with per-source emit timers.
- **Smoke** needs no new protocol — it rides the already-synced `accessoryIndex`.
- **Bubbles/foam** are transient input states, so they ride a new lightweight `ACTIONS` packet (two flag bits) relayed room-scoped like motion, sent only when the local state toggles. The server's `keys`-byte validation rejects `keys > 15`, so a dedicated packet keeps the hot motion path untouched.
- Bumps `protocolVersion` 38 → 39.

## Notes
- Cigarette spray-mode hit detection now keys off the resolved accessory kind, so smoking no longer triggers graffiti.
- Renders are opaque-glow (stylized); true translucency would be a follow-up additive pass.
- Late-joiners see in-progress smoke immediately (accessory is in spawn) but in-progress bubbling/foaming only on the next toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)