### PR TITLE
Improve camera controls

### DIFF
--- a/src/camera-controller.ts
+++ b/src/camera-controller.ts
@@ -10,6 +10,8 @@ const outsideCameraFront = outsideStage.z - outsideStage.depth / 2 - 0.35
 const manualCameraHoldTime = 5000
 const cameraBouncePauseTime = 2500
 const dragMoveThreshold = 3
+const cameraTurnSensitivity = 0.005
+const cameraPitchSensitivity = 0.018
 const firstPersonEyeLift = 0.07
 const firstPersonFaceOffset = 0.18
 const firstPersonLookDistance = 1.4
@@ -44,6 +46,7 @@ export function createCameraController(canvas: HTMLCanvasElement, characterPosit
   const target: Vec3 = [-2.2, -0.75, -6.8]
   const viewUp: Vec3 = [0, 1, 0]
   let firstPerson = false
+  let freeMouse = false
   let turn = 0
   let dragX = 0
   let dragY = 0
@@ -59,12 +62,67 @@ export function createCameraController(canvas: HTMLCanvasElement, characterPosit
 
   function setFirstPerson(value: boolean) {
     firstPerson = value
+    if (firstPerson) {
+      exitFreeMouse()
+    }
     holdingManualCamera = false
     returning = false
     pitch = 0
   }
 
+  function setFreeMouse(value: boolean) {
+    freeMouse = value
+    dragging = false
+    dragMoved = false
+    dragTouchId = -1
+    if (freeMouse) {
+      firstPerson = false
+      holdingManualCamera = true
+      returning = false
+      cameraBouncePausedUntil = performance.now() + cameraBouncePauseTime
+    }
+    else {
+      holdingManualCamera = true
+      manualCameraHoldUntil = performance.now() + manualCameraHoldTime
+    }
+  }
+
+  function enterFreeMouse() {
+    firstPerson = false
+    dragging = false
+    dragMoved = false
+    dragTouchId = -1
+    returning = false
+    canvas.focus()
+    const request = canvas.requestPointerLock()
+
+    request.catch((e: unknown) => console.error(e))
+  }
+
+  function exitFreeMouse() {
+    if (document.pointerLockElement === canvas) {
+      document.exitPointerLock()
+      return
+    }
+
+    if (freeMouse) {
+      setFreeMouse(false)
+    }
+  }
+
+  function syncFreeMouseLock() {
+    const locked = document.pointerLockElement === canvas
+
+    if (freeMouse !== locked) {
+      setFreeMouse(locked)
+    }
+  }
+
   function startDrag(x: number, y: number) {
+    if (freeMouse) {
+      return
+    }
+
     dragging = true
     dragMoved = false
     returning = false
@@ -84,8 +142,12 @@ export function createCameraController(canvas: HTMLCanvasElement, characterPosit
     dragX = x
     dragY = y
 
-    turn -= dx * 0.005
-    pitch = clamp(pitch + dy * 0.018, -2.4, 4.2)
+    moveCamera(dx, dy)
+  }
+
+  function moveCamera(dx: number, dy: number) {
+    turn -= dx * cameraTurnSensitivity
+    pitch = clamp(pitch + dy * cameraPitchSensitivity, -2.4, 4.2)
     holdingManualCamera = true
     manualCameraHoldUntil = performance.now() + manualCameraHoldTime
     cameraBouncePausedUntil = performance.now() + cameraBouncePauseTime
@@ -162,7 +224,7 @@ export function createCameraController(canvas: HTMLCanvasElement, characterPosit
   })
 
   document.addEventListener('mousedown', event => {
-    if (event.button !== 0 || interactiveTarget(event.target)) {
+    if (freeMouse || event.button !== 0 || interactiveTarget(event.target)) {
       return
     }
 
@@ -171,6 +233,12 @@ export function createCameraController(canvas: HTMLCanvasElement, characterPosit
   }, { capture: true })
 
   document.addEventListener('mousemove', event => {
+    if (freeMouse) {
+      event.preventDefault()
+      moveCamera(event.movementX, event.movementY)
+      return
+    }
+
     if (!dragging) {
       return
     }
@@ -182,6 +250,7 @@ export function createCameraController(canvas: HTMLCanvasElement, characterPosit
   document.addEventListener('mouseup', () => {
     dragging = false
   }, { capture: true })
+  document.addEventListener('pointerlockchange', syncFreeMouseLock)
 
   return {
     position,
@@ -191,6 +260,12 @@ export function createCameraController(canvas: HTMLCanvasElement, characterPosit
     },
     set firstPerson(value: boolean) {
       setFirstPerson(value)
+    },
+    get freeMouse() {
+      return freeMouse
+    },
+    set freeMouse(value: boolean) {
+      value ? enterFreeMouse() : exitFreeMouse()
     },
     get turn() {
       return turn
@@ -205,6 +280,10 @@ export function createCameraController(canvas: HTMLCanvasElement, characterPosit
         turn = characterTurn
       }
     },
+    toggleFreeMouse() {
+      freeMouse ? exitFreeMouse() : enterFreeMouse()
+    },
+    exitFreeMouse,
     get() {
       return {
         eye: [position[0], position[1], position[2]] as Vec3,
@@ -230,42 +309,43 @@ export function createCameraController(canvas: HTMLCanvasElement, characterPosit
         : cameraBasis(characterTurn, cameraUp)
       const followTurn = firstPerson ? cameraBasisTurn(faceBasis) : characterTurn
       const sideViewTurn = options.sideViewTurn
+      const manualCameraActive = dragging || freeMouse
 
       if (dragging && !dragMoved) {
         wasMoving = moving
         return
       }
 
-      if (!firstPerson && holdingManualCamera && !dragging && !manualHold
+      if (!firstPerson && holdingManualCamera && !manualCameraActive && !manualHold
         && performance.now() > manualCameraHoldUntil)
       {
         holdingManualCamera = false
       }
 
-      if (!firstPerson && lookDown && !dragging) {
+      if (!firstPerson && lookDown && !manualCameraActive) {
         pitch = mix(pitch, 0.9, 1 - Math.exp(-7 * delta))
       }
 
-      if (!firstPerson && sideViewTurn !== undefined && !dragging && !holdingManualCamera) {
+      if (!firstPerson && sideViewTurn !== undefined && !manualCameraActive && !holdingManualCamera) {
         returning = false
         turn = smoothAngle(turn, sideViewTurn, 5, delta)
         pitch = mix(pitch, 0.05, 1 - Math.exp(-5 * delta))
       }
 
-      if (holdingManualCamera && moving) {
+      if (!freeMouse && holdingManualCamera && moving) {
         holdingManualCamera = false
         returning = true
       }
 
-      if (!dragging && wasMoving && !moving) {
+      if (!manualCameraActive && wasMoving && !moving) {
         returning = true
       }
 
-      if (!dragging && movingBack) {
+      if (!manualCameraActive && movingBack) {
         returning = false
       }
 
-      if (sideViewTurn === undefined && !dragging && ((moving && input[2] >= 0) || returning)) {
+      if (sideViewTurn === undefined && !manualCameraActive && ((moving && input[2] >= 0) || returning)) {
         const turnSpeed = returning ? 5 : mix(0.8, 2.2, input[2])
         const targetPitch = firstPerson ? 0 : lookDown ? 0.9 : 0
 
@@ -281,14 +361,14 @@ export function createCameraController(canvas: HTMLCanvasElement, characterPosit
         }
       }
 
-      if (firstPerson && !dragging && !holdingManualCamera && !returning) {
+      if (firstPerson && !manualCameraActive && !holdingManualCamera && !returning) {
         turn = followTurn
         pitch = 0
       }
 
       wasMoving = moving
 
-      const basis = firstPerson && !dragging && !holdingManualCamera && !returning
+      const basis = firstPerson && !manualCameraActive && !holdingManualCamera && !returning
         ? faceBasis
         : cameraBasis(turn, firstPerson ? options.face?.up ?? cameraUp : cameraUp)
 
@@ -335,7 +415,7 @@ export function createCameraController(canvas: HTMLCanvasElement, characterPosit
       }
       const zone = loft ? 'loft' : roomAt(characterPosition)
 
-      if (holdingManualCamera && !dragging) {
+      if (holdingManualCamera && !manualCameraActive) {
         clampCameraToZone(position, zone, characterPosition)
         wasMoving = moving
         return
@@ -346,7 +426,7 @@ export function createCameraController(canvas: HTMLCanvasElement, characterPosit
       const crossingOutside = outside && !cameraOutside
       const elevatedOutside = outside && characterPosition[1] > characterFloor + 0.8
       const time = performance.now() * 0.001
-      const bouncePaused = dragging || performance.now() < cameraBouncePausedUntil
+      const bouncePaused = manualCameraActive || performance.now() < cameraBouncePausedUntil
       const bounceAllowed = bounceActive && !bouncePaused
       const distance = bounceAllowed && !outside ? cameraDanceDistance(time) : 2.2
       const bounce = bounceAllowed ? cameraDanceBounce(time) : 0

--- a/src/camera-controller.ts
+++ b/src/camera-controller.ts
@@ -88,7 +88,6 @@ export function createCameraController(canvas: HTMLCanvasElement, characterPosit
   }
 
   function enterFreeMouse() {
-    firstPerson = false
     dragging = false
     dragMoved = false
     dragTouchId = -1
@@ -102,6 +101,7 @@ export function createCameraController(canvas: HTMLCanvasElement, characterPosit
   function exitFreeMouse() {
     if (document.pointerLockElement === canvas) {
       document.exitPointerLock()
+      setFreeMouse(false)
       return
     }
 

--- a/src/club-app.ts
+++ b/src/club-app.ts
@@ -189,6 +189,7 @@ const {
   sunglassesOverlay,
   sunglassesButton,
   perspectiveButton,
+  cameraButton,
   breakdanceButton,
   waveButton,
   bubbleButton,
@@ -482,6 +483,7 @@ function syncOnlineIndicator() {
   reactionButtons.dataset.hidden = String(helpUi.root.dataset.open === 'true')
   sunglassesButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
   perspectiveButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
+  cameraButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
   breakdanceButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
   waveButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
   bubbleButton.dataset.hidden = String(helpUi.root.dataset.open === 'true')
@@ -1456,17 +1458,34 @@ function toggleSunglasses() {
   setSunglasses(!sunglasses)
 }
 
-function syncFreeMouseButton() {
-  perspectiveButton.dataset.active = String(cameraController.freeMouse)
-  perspectiveButton.setAttribute('aria-pressed', String(cameraController.freeMouse))
+function syncViewButton() {
+  const active = cameraController.firstPerson
+
+  perspectiveButton.dataset.active = String(active)
+  perspectiveButton.setAttribute('aria-pressed', String(active))
 }
 
-function toggleFreeMouse() {
+function syncCameraButton() {
+  const active = cameraController.freeMouse
+
+  cameraButton.dataset.active = String(active)
+  cameraButton.setAttribute('aria-pressed', String(active))
+}
+
+function toggleView() {
+  cameraController.togglePerspective(localCharacter.turn)
+  syncViewButton()
+  syncCameraButton()
+  saveCurrentClubState(true)
+}
+
+function toggleCameraControl() {
   cameraController.toggleFreeMouse()
-  syncFreeMouseButton()
+  syncCameraButton()
+  syncViewButton()
 }
 
-document.addEventListener('pointerlockchange', syncFreeMouseButton)
+document.addEventListener('pointerlockchange', syncCameraButton)
 
 function palmTreeMeshColor(index: number): [number, number, number] {
   return index === 0 ? [0.42, 0.24, 0.1] : [0.02, 0.72 + (index % 3) * 0.08, 0.16]
@@ -2318,7 +2337,8 @@ restoreClubState({
   setInputLayout: useInputLayout,
   styleController,
 })
-syncFreeMouseButton()
+syncViewButton()
+syncCameraButton()
 djVideoUi.setZoneFromPosition()
 djVideoUi.load()
 
@@ -3327,7 +3347,8 @@ bindKeyboardInput({
   },
   startBreakdance: () => localCharacter.startBreakdance(),
   toggleSunglasses,
-  toggleFreeMouse,
+  toggleCameraControl,
+  toggleView,
   openChatInput: () => openChatInput(),
   setInputLayout: useInputLayout,
   toggleHelp: () => {
@@ -3582,7 +3603,12 @@ sunglassesButton.addEventListener('click', () => {
 })
 
 perspectiveButton.addEventListener('click', () => {
-  toggleFreeMouse()
+  toggleView()
+  canvas.focus()
+})
+
+cameraButton.addEventListener('click', () => {
+  toggleCameraControl()
   canvas.focus()
 })
 
@@ -3637,7 +3663,8 @@ window.addEventListener('keydown', event => {
   if (event.key === 'Escape' && cameraController.freeMouse) {
     event.preventDefault()
     cameraController.exitFreeMouse()
-    syncFreeMouseButton()
+    syncViewButton()
+    syncCameraButton()
     canvas.focus()
     return
   }

--- a/src/club-app.ts
+++ b/src/club-app.ts
@@ -29,7 +29,8 @@ import {
   paintTShirtLogoTexture,
   sprayWallPoint,
 } from './graffiti.ts'
-import { bindKeyboardInput, setAlternativeInput } from './input.ts'
+import { bindKeyboardInput, setInputLayout } from './input.ts'
+import type { InputLayout } from './input.ts'
 import { addLoftLightGeometry, addLoftRoom, addLoftSmoke, loftSpawn } from './loft-scene.ts'
 import { lengthSq, mix } from './math.ts'
 import { createMultiplayer, updateRemotePlayers } from './multiplayer.ts'
@@ -311,7 +312,7 @@ const remoteSeats = new Set<string>()
 const maxNpcPlayers = 400
 const npcPopulationInterval = 60_000
 let idleClipIndex = 0
-let alternativeInput = true
+let inputLayout: InputLayout = 'wasd'
 let onlineCountValue = 0
 let nextNpcPopulationSyncAt = npcPopulationInterval
 const localCharacter = createLocalCharacter(keys)
@@ -356,7 +357,7 @@ const djVideoUi = createDjVideoUi(djVideo, characterPosition, {
 })
 const photoWallUi = createPhotoWallUi(photoWall, {
   admin: () => ({ enabled: adminView, pass: adminPass }),
-  alternativeInput: () => alternativeInput,
+  inputLayout: () => inputLayout,
   onLike: photo => sendChatMessage('❤️', photo.timestamp),
   recoverFocus: () => canvas.focus(),
 })
@@ -1429,10 +1430,10 @@ const idleClipState = {
     idleClipIndex = value
   },
 }
-function useAlternativeInput(value: boolean) {
-  alternativeInput = value
-  setAlternativeInput(value)
-  helpUi.setAlternativeInput(value)
+function useInputLayout(value: InputLayout) {
+  inputLayout = value
+  setInputLayout(value)
+  helpUi.setInputLayout(value)
 }
 
 function setSunglasses(value: boolean) {
@@ -1455,16 +1456,17 @@ function toggleSunglasses() {
   setSunglasses(!sunglasses)
 }
 
-function syncPerspectiveButton() {
-  perspectiveButton.dataset.active = String(cameraController.firstPerson)
-  perspectiveButton.setAttribute('aria-pressed', String(cameraController.firstPerson))
+function syncFreeMouseButton() {
+  perspectiveButton.dataset.active = String(cameraController.freeMouse)
+  perspectiveButton.setAttribute('aria-pressed', String(cameraController.freeMouse))
 }
 
-function togglePerspective() {
-  cameraController.togglePerspective(localCharacter.turn)
-  syncPerspectiveButton()
-  saveCurrentClubState(true)
+function toggleFreeMouse() {
+  cameraController.toggleFreeMouse()
+  syncFreeMouseButton()
 }
+
+document.addEventListener('pointerlockchange', syncFreeMouseButton)
 
 function palmTreeMeshColor(index: number): [number, number, number] {
   return index === 0 ? [0.42, 0.24, 0.1] : [0.02, 0.72 + (index % 3) * 0.08, 0.16]
@@ -1808,7 +1810,7 @@ function seededPlantRandom(seed: number, salt: number) {
   return value - Math.floor(value)
 }
 
-useAlternativeInput(alternativeInput)
+useInputLayout(inputLayout)
 const projectorViewport: Viewport = {
   clientHeight: canvas.clientHeight,
   clientWidth: canvas.clientWidth,
@@ -2313,10 +2315,10 @@ restoreClubState({
   idleClipIndex: idleClipState,
   key: saveKey,
   localCharacter,
-  setAlternativeInput: useAlternativeInput,
+  setInputLayout: useInputLayout,
   styleController,
 })
-syncPerspectiveButton()
+syncFreeMouseButton()
 djVideoUi.setZoneFromPosition()
 djVideoUi.load()
 
@@ -3290,7 +3292,7 @@ function saveCurrentClubState(characterAssetsLoaded: boolean, room = currentRoom
     characterPosition,
     duckPosition,
     duckTurn,
-    alternativeInput,
+    inputLayout,
     hairController,
     idleClipIndex,
     instagram,
@@ -3325,9 +3327,9 @@ bindKeyboardInput({
   },
   startBreakdance: () => localCharacter.startBreakdance(),
   toggleSunglasses,
-  togglePerspective,
+  toggleFreeMouse,
   openChatInput: () => openChatInput(),
-  setAlternativeInput: useAlternativeInput,
+  setInputLayout: useInputLayout,
   toggleHelp: () => {
     const open = helpUi.toggle()
     syncOnlineIndicator()
@@ -3580,7 +3582,7 @@ sunglassesButton.addEventListener('click', () => {
 })
 
 perspectiveButton.addEventListener('click', () => {
-  togglePerspective()
+  toggleFreeMouse()
   canvas.focus()
 })
 
@@ -3632,6 +3634,14 @@ for (const eventName of ['pointerup', 'pointercancel', 'lostpointercapture']) {
 }
 
 window.addEventListener('keydown', event => {
+  if (event.key === 'Escape' && cameraController.freeMouse) {
+    event.preventDefault()
+    cameraController.exitFreeMouse()
+    syncFreeMouseButton()
+    canvas.focus()
+    return
+  }
+
   if (event.key === 'Escape' && chatUi.isOpen()) {
     event.preventDefault()
     chatUi.close()

--- a/src/club-app.ts
+++ b/src/club-app.ts
@@ -1472,20 +1472,23 @@ function syncCameraButton() {
   cameraButton.setAttribute('aria-pressed', String(active))
 }
 
-function toggleView() {
-  cameraController.togglePerspective(localCharacter.turn)
+function syncCameraControls() {
   syncViewButton()
   syncCameraButton()
+}
+
+function toggleView() {
+  cameraController.togglePerspective(localCharacter.turn)
+  syncCameraControls()
   saveCurrentClubState(true)
 }
 
 function toggleCameraControl() {
   cameraController.toggleFreeMouse()
-  syncCameraButton()
-  syncViewButton()
+  syncCameraControls()
 }
 
-document.addEventListener('pointerlockchange', syncCameraButton)
+document.addEventListener('pointerlockchange', syncCameraControls)
 
 function palmTreeMeshColor(index: number): [number, number, number] {
   return index === 0 ? [0.42, 0.24, 0.1] : [0.02, 0.72 + (index % 3) * 0.08, 0.16]
@@ -2337,8 +2340,7 @@ restoreClubState({
   setInputLayout: useInputLayout,
   styleController,
 })
-syncViewButton()
-syncCameraButton()
+syncCameraControls()
 djVideoUi.setZoneFromPosition()
 djVideoUi.load()
 
@@ -3663,8 +3665,7 @@ window.addEventListener('keydown', event => {
   if (event.key === 'Escape' && cameraController.freeMouse) {
     event.preventDefault()
     cameraController.exitFreeMouse()
-    syncViewButton()
-    syncCameraButton()
+    syncCameraControls()
     canvas.focus()
     return
   }

--- a/src/club-persistence.ts
+++ b/src/club-persistence.ts
@@ -56,10 +56,21 @@ export function restoreClubState(options: {
       ?? options.styleController.topStyleIndex, jewelPalette.length * 2 + 2)
     options.styleController.bottomStyleIndex = normalizeIndex(state.bottomStyleIndex ?? state.pantsColorIndex
       ?? options.styleController.bottomStyleIndex, jewelPalette.length * 2)
-    options.setInputLayout(state.inputLayout ?? (state.alternativeInput ?? true ? 'wasd' : 'ijkl'))
+    options.setInputLayout(restoreInputLayout(state.inputLayout, state.alternativeInput))
     options.styleController.setTopStyle()
     options.styleController.setBottomStyle()
   }
+}
+
+/**
+ * Restores the new layout enum while preserving saves from the old two-layout boolean setting.
+ */
+function restoreInputLayout(value: unknown, alternativeInput: boolean | undefined): InputLayout {
+  if (value === 'wasd' || value === 'ijkl' || value === 'zqsd') {
+    return value
+  }
+
+  return alternativeInput ?? true ? 'wasd' : 'ijkl'
 }
 
 export function saveClubState(options: {

--- a/src/club-persistence.ts
+++ b/src/club-persistence.ts
@@ -5,6 +5,7 @@ import { readClubState, writeClubState } from './club-state.ts'
 import { createLocalCharacter } from './local-character.ts'
 import { normalizeIndex, setVec3 } from './math.ts'
 import type { DuckPose } from './duck-position.ts'
+import type { InputLayout } from './input.ts'
 import type { Vec3 } from './types.ts'
 
 export function restoreClubState(options: {
@@ -17,7 +18,7 @@ export function restoreClubState(options: {
   duckTurn: number
   setDuckPose: (pose: DuckPose) => void
   hairController: ReturnType<typeof createCharacterHairController>
-  setAlternativeInput: (value: boolean) => void
+  setInputLayout: (value: InputLayout) => void
   idleClipIndex: {
     set(value: number): void
   }
@@ -55,7 +56,7 @@ export function restoreClubState(options: {
       ?? options.styleController.topStyleIndex, jewelPalette.length * 2 + 2)
     options.styleController.bottomStyleIndex = normalizeIndex(state.bottomStyleIndex ?? state.pantsColorIndex
       ?? options.styleController.bottomStyleIndex, jewelPalette.length * 2)
-    options.setAlternativeInput(state.alternativeInput ?? true)
+    options.setInputLayout(state.inputLayout ?? (state.alternativeInput ?? true ? 'wasd' : 'ijkl'))
     options.styleController.setTopStyle()
     options.styleController.setBottomStyle()
   }
@@ -72,7 +73,7 @@ export function saveClubState(options: {
   duckPosition: Vec3
   duckTurn: number
   hairController: ReturnType<typeof createCharacterHairController>
-  alternativeInput: boolean
+  inputLayout: InputLayout
   idleClipIndex: number
   instagram: string
   key: string
@@ -104,7 +105,8 @@ export function saveClubState(options: {
     pantsColorIndex: options.styleController.pantsColorIndex,
     bottomStyleIndex: options.styleController.bottomStyleIndex,
     accessoryIndex: options.styleController.accessoryIndex,
-    alternativeInput: options.alternativeInput,
+    alternativeInput: options.inputLayout !== 'ijkl',
+    inputLayout: options.inputLayout,
     sunglasses: options.sunglasses,
     instagram: options.instagram,
     nickname: options.nickname,

--- a/src/club-state.ts
+++ b/src/club-state.ts
@@ -1,3 +1,4 @@
+import type { InputLayout } from './input.ts'
 import type { Vec3 } from './types.ts'
 
 export type ClubState = {
@@ -19,6 +20,7 @@ export type ClubState = {
   bottomStyleIndex?: number
   accessoryIndex?: number
   alternativeInput?: boolean
+  inputLayout?: InputLayout
   sunglasses?: boolean
   instagram?: string
   nickname?: string

--- a/src/dom-elements.ts
+++ b/src/dom-elements.ts
@@ -105,7 +105,7 @@ function createDomElements() {
   perspectiveButton.id = 'perspective-button'
   perspectiveButton.type = 'button'
   perspectiveButton.textContent = '👀'
-  perspectiveButton.setAttribute('aria-label', 'first person view')
+  perspectiveButton.setAttribute('aria-label', 'free mouse camera')
   perspectiveButton.setAttribute('aria-pressed', 'false')
   breakdanceButton.id = 'breakdance-button'
   breakdanceButton.type = 'button'

--- a/src/dom-elements.ts
+++ b/src/dom-elements.ts
@@ -25,6 +25,7 @@ function createDomElements() {
   const photoButton = document.createElement('button')
   const sunglassesButton = document.createElement('button')
   const perspectiveButton = document.createElement('button')
+  const cameraButton = document.createElement('button')
   const breakdanceButton = document.createElement('button')
   const waveButton = document.createElement('button')
   const bubbleButton = document.createElement('button')
@@ -105,8 +106,13 @@ function createDomElements() {
   perspectiveButton.id = 'perspective-button'
   perspectiveButton.type = 'button'
   perspectiveButton.textContent = '👀'
-  perspectiveButton.setAttribute('aria-label', 'free mouse camera')
+  perspectiveButton.setAttribute('aria-label', 'view mode')
   perspectiveButton.setAttribute('aria-pressed', 'false')
+  cameraButton.id = 'camera-button'
+  cameraButton.type = 'button'
+  cameraButton.textContent = '🖱️'
+  cameraButton.setAttribute('aria-label', 'camera control')
+  cameraButton.setAttribute('aria-pressed', 'false')
   breakdanceButton.id = 'breakdance-button'
   breakdanceButton.type = 'button'
   breakdanceButton.textContent = '🤸'
@@ -211,7 +217,7 @@ function createDomElements() {
   intro.append(introEffect, introPanel, introGithub)
   document.body.prepend(canvas, djVideo, photoWall, scheduleWall, sunglassesOverlay, chatForm, chatBubble,
     onlineIndicator, reactionButtons, waveButton, bubbleButton, foamButton, breakdanceButton, sunglassesButton,
-    perspectiveButton, photoButton, roomsButton, supportLink, merchCards, intro)
+    perspectiveButton, cameraButton, photoButton, roomsButton, supportLink, merchCards, intro)
 
   return {
     canvas,
@@ -230,6 +236,7 @@ function createDomElements() {
     sunglassesOverlay,
     sunglassesButton,
     perspectiveButton,
+    cameraButton,
     breakdanceButton,
     waveButton,
     bubbleButton,

--- a/src/help-ui.ts
+++ b/src/help-ui.ts
@@ -49,7 +49,8 @@ const actionRow: HelpKey[] = [
 ]
 const alternativeActionRow: HelpKey[] = [
   { keys: ['g'], label: 'sunglasses' },
-  { keys: ['t'], label: 'free mouse' },
+  { keys: ['t'], label: 'view' },
+  { keys: ['f'], label: 'camera' },
   { keys: ['y'], label: 'breakdance' },
 ]
 

--- a/src/help-ui.ts
+++ b/src/help-ui.ts
@@ -1,3 +1,5 @@
+import type { InputLayout } from './input.ts'
+
 type HelpKey = {
   keys: string[]
   label: string
@@ -47,7 +49,7 @@ const actionRow: HelpKey[] = [
 ]
 const alternativeActionRow: HelpKey[] = [
   { keys: ['g'], label: 'sunglasses' },
-  { keys: ['t'], label: 'view' },
+  { keys: ['t'], label: 'free mouse' },
   { keys: ['y'], label: 'breakdance' },
 ]
 
@@ -64,6 +66,14 @@ const alternativeMoveRows: HelpKey[][] = [
   [{ keys: ['↑', 'w'], label: 'forward' }],
   [
     { keys: ['←', 'a'], label: 'left' },
+    { keys: ['↓', 's'], label: 'back' },
+    { keys: ['→', 'd'], label: 'right' },
+  ],
+]
+const azertyMoveRows: HelpKey[][] = [
+  [{ keys: ['↑', 'z'], label: 'forward' }],
+  [
+    { keys: ['←', 'q'], label: 'left' },
     { keys: ['↓', 's'], label: 'back' },
     { keys: ['→', 'd'], label: 'right' },
   ],
@@ -114,11 +124,15 @@ export function createHelpUi() {
       return open
     },
     dismissVideoHint,
-    setAlternativeInput(value: boolean) {
-      renderCluster(left, value ? alternativeLeftRows : leftRows)
-      renderCluster(move, value ? alternativeMoveRows : moveRows)
+    setInputLayout(value: InputLayout) {
+      renderCluster(left, value === 'ijkl' ? leftRows : alternativeLeftRows)
+      renderCluster(move, moveRowsForLayout(value))
     },
   }
+}
+
+function moveRowsForLayout(value: InputLayout) {
+  return value === 'ijkl' ? moveRows : value === 'wasd' ? alternativeMoveRows : azertyMoveRows
 }
 
 function dismissVideoHint() {

--- a/src/help-ui.ts
+++ b/src/help-ui.ts
@@ -130,7 +130,7 @@ function alternativeActionRowForLayout(value: InputLayout): HelpKey[] {
   return [
     { keys: ['g'], label: 'sunglasses' },
     { keys: ['t'], label: 'view' },
-    { keys: [value === 'ijkl' ? ';' : 'f'], label: 'camera' },
+    { keys: [value === 'ijkl' ? 'o' : 'f'], label: 'camera' },
     { keys: ['y'], label: 'breakdance' },
   ]
 }

--- a/src/help-ui.ts
+++ b/src/help-ui.ts
@@ -47,13 +47,6 @@ const actionRow: HelpKey[] = [
   { keys: ['b'], label: 'bounce' },
   { keys: ['n'], label: 'foam' },
 ]
-const alternativeActionRow: HelpKey[] = [
-  { keys: ['g'], label: 'sunglasses' },
-  { keys: ['t'], label: 'view' },
-  { keys: ['f'], label: 'camera' },
-  { keys: ['y'], label: 'breakdance' },
-]
-
 const moveRows: HelpKey[][] = [
   [{ keys: ['↑', 'i'], label: 'forward' }],
   [
@@ -85,7 +78,7 @@ export function createHelpUi() {
   const left = document.createElement('div')
   const move = document.createElement('div')
   const actions = helpRow(actionRow)
-  const alternativeActions = helpRow(alternativeActionRow)
+  const alternativeActions = helpRow(alternativeActionRowForLayout('wasd'))
   const speak = helpBox({ keys: ['space'], label: 'speak' })
   const alternative = helpBox({ keys: ['tab'], label: 'alt inputs' })
   const toggle = helpBox({ keys: ['?', 'h'], label: 'help' })
@@ -128,8 +121,18 @@ export function createHelpUi() {
     setInputLayout(value: InputLayout) {
       renderCluster(left, value === 'ijkl' ? leftRows : alternativeLeftRows)
       renderCluster(move, moveRowsForLayout(value))
+      renderRow(alternativeActions, alternativeActionRowForLayout(value))
     },
   }
+}
+
+function alternativeActionRowForLayout(value: InputLayout): HelpKey[] {
+  return [
+    { keys: ['g'], label: 'sunglasses' },
+    { keys: ['t'], label: 'view' },
+    { keys: [value === 'ijkl' ? ';' : 'f'], label: 'camera' },
+    { keys: ['y'], label: 'breakdance' },
+  ]
 }
 
 function moveRowsForLayout(value: InputLayout) {
@@ -142,6 +145,10 @@ function dismissVideoHint() {
 
 function renderCluster(cluster: HTMLElement, rows: HelpKey[][]) {
   cluster.replaceChildren(...rows.map(helpRow))
+}
+
+function renderRow(row: HTMLElement, items: HelpKey[]) {
+  row.replaceChildren(...items.map(helpBox))
 }
 
 function helpRow(items: HelpKey[]) {

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,14 +1,19 @@
 import type { Vec3 } from './types.ts'
 
-let alternativeInput = true
+export type InputLayout = 'wasd' | 'ijkl' | 'zqsd'
+
+const inputLayouts: InputLayout[] = ['wasd', 'ijkl', 'zqsd']
+const moveKeys: Record<InputLayout, { back: string; forward: string; left: string; right: string }> = {
+  ijkl: { back: 'k', forward: 'i', left: 'j', right: 'l' },
+  wasd: { back: 's', forward: 'w', left: 'a', right: 'd' },
+  zqsd: { back: 's', forward: 'z', left: 'q', right: 'd' },
+}
+let inputLayout: InputLayout = 'wasd'
 let touchMoveX = 0
 let touchMoveZ = 0
 
 export function readMoveInput(keys: Set<string>, target: Vec3) {
-  const left = alternativeInput ? 'a' : 'j'
-  const right = alternativeInput ? 'd' : 'l'
-  const forward = alternativeInput ? 'w' : 'i'
-  const back = alternativeInput ? 's' : 'k'
+  const { back, forward, left, right } = moveKeys[inputLayout]
 
   target[0] = Number(keys.has(right) || keys.has('arrowright')) - Number(keys.has(left) || keys.has('arrowleft'))
     + touchMoveX
@@ -19,8 +24,8 @@ export function readMoveInput(keys: Set<string>, target: Vec3) {
   return target
 }
 
-export function setAlternativeInput(value: boolean) {
-  alternativeInput = value
+export function setInputLayout(value: InputLayout) {
+  inputLayout = value
 }
 
 export function setTouchMoveInput(x: number, z: number) {
@@ -36,7 +41,7 @@ export function bindKeyboardInput(options: {
   activeInputs: HTMLInputElement[]
   keys: Set<string>
   openChatInput: () => void
-  setAlternativeInput: (value: boolean) => void
+  setInputLayout: (value: InputLayout) => void
   toggleHelp: () => void
   startJumping: () => void
   stopJumping: () => void
@@ -55,7 +60,7 @@ export function bindKeyboardInput(options: {
   cyclePants: (direction: number) => void
   cycleAccessory: (direction: number) => void
   toggleSunglasses: () => void
-  togglePerspective: () => void
+  toggleFreeMouse: () => void
 }) {
   window.addEventListener('keydown', event => {
     if (options.activeInputs.includes(document.activeElement as HTMLInputElement)) {
@@ -70,13 +75,14 @@ export function bindKeyboardInput(options: {
 
     if (event.code === 'Tab') {
       event.preventDefault()
-      alternativeInput = !alternativeInput
+      inputLayout = inputLayouts[(inputLayouts.indexOf(inputLayout) + 1) % inputLayouts.length]!
       options.keys.clear()
-      options.setAlternativeInput(alternativeInput)
+      options.setInputLayout(inputLayout)
       return
     }
 
     const key = event.key.toLowerCase()
+    const alternativeStyleInput = inputLayout !== 'ijkl'
 
     if (key === '?' || key === 'h') {
       options.toggleHelp()
@@ -124,7 +130,7 @@ export function bindKeyboardInput(options: {
       }
 
       options.keys.add(key)
-      options.togglePerspective()
+      options.toggleFreeMouse()
       return
     }
 
@@ -138,72 +144,72 @@ export function bindKeyboardInput(options: {
       return
     }
 
-    if ((!alternativeInput && key === 'q') || (alternativeInput && key === 'u')) {
+    if ((!alternativeStyleInput && key === 'q') || (alternativeStyleInput && key === 'u')) {
       options.cycleHair(-1)
       return
     }
 
-    if ((!alternativeInput && key === 'w') || (alternativeInput && key === 'i')) {
+    if ((!alternativeStyleInput && key === 'w') || (alternativeStyleInput && key === 'i')) {
       options.cycleHair(1)
       return
     }
 
-    if ((!alternativeInput && key === 'd') || (alternativeInput && key === 'l')) {
+    if ((!alternativeStyleInput && key === 'd') || (alternativeStyleInput && key === 'l')) {
       options.cycleIdle(-1)
       return
     }
 
-    if ((!alternativeInput && key === 'f') || (alternativeInput && key === ';')) {
+    if ((!alternativeStyleInput && key === 'f') || (alternativeStyleInput && key === ';')) {
       options.cycleIdle(1)
       return
     }
 
-    if ((!alternativeInput && event.key === '1') || (alternativeInput && event.key === '7')) {
+    if ((!alternativeStyleInput && event.key === '1') || (alternativeStyleInput && event.key === '7')) {
       options.cycleHairColor(-1)
       return
     }
 
-    if ((!alternativeInput && event.key === '2') || (alternativeInput && event.key === '8')) {
+    if ((!alternativeStyleInput && event.key === '2') || (alternativeStyleInput && event.key === '8')) {
       options.cycleHairColor(1)
       return
     }
 
-    if ((!alternativeInput && event.key === '3') || (alternativeInput && event.key === '9')) {
+    if ((!alternativeStyleInput && event.key === '3') || (alternativeStyleInput && event.key === '9')) {
       options.cycleSkin(-1)
       return
     }
 
-    if ((!alternativeInput && event.key === '4') || (alternativeInput && event.key === '0')) {
+    if ((!alternativeStyleInput && event.key === '4') || (alternativeStyleInput && event.key === '0')) {
       options.cycleSkin(1)
       return
     }
 
-    if ((!alternativeInput && key === 'a') || (alternativeInput && key === 'j')) {
+    if ((!alternativeStyleInput && key === 'a') || (alternativeStyleInput && key === 'j')) {
       options.cycleShirt(-1)
       return
     }
 
-    if ((!alternativeInput && key === 's') || (alternativeInput && key === 'k')) {
+    if ((!alternativeStyleInput && key === 's') || (alternativeStyleInput && key === 'k')) {
       options.cycleShirt(1)
       return
     }
 
-    if ((!alternativeInput && key === 'z') || (alternativeInput && key === 'm')) {
+    if ((!alternativeStyleInput && key === 'z') || (alternativeStyleInput && key === 'm')) {
       options.cyclePants(-1)
       return
     }
 
-    if ((!alternativeInput && key === 'x') || (alternativeInput && key === ',')) {
+    if ((!alternativeStyleInput && key === 'x') || (alternativeStyleInput && key === ',')) {
       options.cyclePants(1)
       return
     }
 
-    if ((!alternativeInput && key === 'e') || (alternativeInput && key === 'o')) {
+    if ((!alternativeStyleInput && key === 'e') || (alternativeStyleInput && key === 'o')) {
       options.cycleAccessory(-1)
       return
     }
 
-    if ((!alternativeInput && key === 'r') || (alternativeInput && key === 'p')) {
+    if ((!alternativeStyleInput && key === 'r') || (alternativeStyleInput && key === 'p')) {
       options.cycleAccessory(1)
       return
     }

--- a/src/input.ts
+++ b/src/input.ts
@@ -135,7 +135,7 @@ export function bindKeyboardInput(options: {
       return
     }
 
-    const cameraKey = inputLayout === 'ijkl' ? ';' : 'f'
+    const cameraKey = inputLayout === 'ijkl' ? 'o' : 'f'
 
     if (key === cameraKey) {
       if (options.keys.has(key)) {

--- a/src/input.ts
+++ b/src/input.ts
@@ -60,7 +60,8 @@ export function bindKeyboardInput(options: {
   cyclePants: (direction: number) => void
   cycleAccessory: (direction: number) => void
   toggleSunglasses: () => void
-  toggleFreeMouse: () => void
+  toggleCameraControl: () => void
+  toggleView: () => void
 }) {
   window.addEventListener('keydown', event => {
     if (options.activeInputs.includes(document.activeElement as HTMLInputElement)) {
@@ -130,7 +131,17 @@ export function bindKeyboardInput(options: {
       }
 
       options.keys.add(key)
-      options.toggleFreeMouse()
+      options.toggleView()
+      return
+    }
+
+    if (key === 'f') {
+      if (options.keys.has(key)) {
+        return
+      }
+
+      options.keys.add(key)
+      options.toggleCameraControl()
       return
     }
 

--- a/src/input.ts
+++ b/src/input.ts
@@ -135,7 +135,9 @@ export function bindKeyboardInput(options: {
       return
     }
 
-    if (key === 'f') {
+    const cameraKey = inputLayout === 'ijkl' ? ';' : 'f'
+
+    if (key === cameraKey) {
       if (options.keys.has(key)) {
         return
       }

--- a/src/photo-wall-ui.ts
+++ b/src/photo-wall-ui.ts
@@ -8,6 +8,7 @@ import {
   photoWallSurface,
 } from './photo-wall-data.ts'
 import { projectedQuadTransform, type WallProjector } from './projection.ts'
+import type { InputLayout } from './input.ts'
 import type { Vec3 } from './types.ts'
 
 type Camera = {
@@ -54,7 +55,7 @@ const viewerSlideDuration = 420
 
 export function createPhotoWallUi(element: HTMLElement, options: {
   admin: () => { enabled: boolean; pass: string }
-  alternativeInput: () => boolean
+  inputLayout: () => InputLayout
   onLike?: (photo: Photo) => void
   recoverFocus?: () => void
 }) {
@@ -176,8 +177,7 @@ export function createPhotoWallUi(element: HTMLElement, options: {
   })
   viewer.addEventListener('keydown', event => {
     const key = event.key.toLowerCase()
-    const previousKey = options.alternativeInput() ? 'a' : 'j'
-    const nextKey = options.alternativeInput() ? 'd' : 'l'
+    const [previousKey, nextKey] = viewerNavigationKeys(options.inputLayout())
 
     event.stopPropagation()
     if (event.key === 'Escape' || key === 'x') {
@@ -1039,6 +1039,10 @@ export function createPhotoWallUi(element: HTMLElement, options: {
     })
     viewerAnimation.addEventListener('finish', closeViewerNow, { once: true })
   }
+}
+
+function viewerNavigationKeys(inputLayout: InputLayout) {
+  return inputLayout === 'ijkl' ? ['j', 'l'] : inputLayout === 'wasd' ? ['a', 'd'] : ['q', 'd']
 }
 
 function photoTilt(photo: Photo) {

--- a/src/style.css
+++ b/src/style.css
@@ -556,6 +556,7 @@ body[data-arcade-open="true"] #online-indicator,
 body[data-arcade-open="true"] #reaction-buttons,
 body[data-arcade-open="true"] #sunglasses-button,
 body[data-arcade-open="true"] #perspective-button,
+body[data-arcade-open="true"] #camera-button,
 body[data-arcade-open="true"] #breakdance-button,
 body[data-arcade-open="true"] #wave-button,
 body[data-arcade-open="true"] #bubble-button,
@@ -976,6 +977,7 @@ body[data-intro-visible="true"] #online-indicator,
 body[data-intro-visible="true"] #reaction-buttons,
 body[data-intro-visible="true"] #sunglasses-button,
 body[data-intro-visible="true"] #perspective-button,
+body[data-intro-visible="true"] #camera-button,
 body[data-intro-visible="true"] #wave-button,
 body[data-intro-visible="true"] #bubble-button,
 body[data-intro-visible="true"] #foam-button,
@@ -1116,6 +1118,7 @@ html[data-touch-controls="true"] #reaction-buttons[data-hidden="true"] {
 #breakdance-button,
 #sunglasses-button,
 #perspective-button,
+#camera-button,
 #wave-button,
 #bubble-button,
 #foam-button,
@@ -1139,6 +1142,7 @@ html[data-touch-controls="true"] #reaction-buttons[data-hidden="true"] {
 #breakdance-button,
 #sunglasses-button,
 #perspective-button,
+#camera-button,
 #wave-button,
 #bubble-button,
 #foam-button,
@@ -1168,7 +1172,7 @@ html[data-touch-controls="true"] #reaction-buttons[data-hidden="true"] {
 }
 
 #sunglasses-button {
-  bottom: calc(12px + var(--app-bottom) + (var(--action-size) + var(--action-gap)) * 8);
+  bottom: calc(12px + var(--app-bottom) + (var(--action-size) + var(--action-gap)) * 9);
 }
 
 #sunglasses-button[data-active="true"] {
@@ -1185,6 +1189,16 @@ html[data-touch-controls="true"] #reaction-buttons[data-hidden="true"] {
   text-shadow:
     0 0 8px rgb(0 245 255 / 0.82),
     0 0 18px rgb(45 120 255 / 0.9);
+}
+
+#camera-button {
+  bottom: calc(12px + var(--app-bottom) + (var(--action-size) + var(--action-gap)) * 8);
+}
+
+#camera-button[data-active="true"] {
+  text-shadow:
+    0 0 8px rgb(255 255 255 / 0.82),
+    0 0 18px rgb(0 245 255 / 0.9);
 }
 
 #photo-button {
@@ -1214,6 +1228,7 @@ html[data-touch-controls="true"] #reaction-buttons[data-hidden="true"] {
 #breakdance-button[data-hidden="true"],
 #sunglasses-button[data-hidden="true"],
 #perspective-button[data-hidden="true"],
+#camera-button[data-hidden="true"],
 #wave-button[data-hidden="true"],
 #bubble-button[data-hidden="true"],
 #foam-button[data-hidden="true"],
@@ -1226,6 +1241,7 @@ html[data-touch-controls="true"] #reaction-buttons[data-hidden="true"] {
 html[data-touch-controls="true"] #breakdance-button[data-hidden="true"],
 html[data-touch-controls="true"] #sunglasses-button[data-hidden="true"],
 html[data-touch-controls="true"] #perspective-button[data-hidden="true"],
+html[data-touch-controls="true"] #camera-button[data-hidden="true"],
 html[data-touch-controls="true"] #wave-button[data-hidden="true"],
 html[data-touch-controls="true"] #bubble-button[data-hidden="true"],
 html[data-touch-controls="true"] #foam-button[data-hidden="true"],
@@ -1239,6 +1255,7 @@ html[data-touch-controls="true"] body:has(#mobile-controls[data-open="true"]) #r
 html[data-touch-controls="true"] body:has(#mobile-controls[data-open="true"]) #breakdance-button,
 html[data-touch-controls="true"] body:has(#mobile-controls[data-open="true"]) #sunglasses-button,
 html[data-touch-controls="true"] body:has(#mobile-controls[data-open="true"]) #perspective-button,
+html[data-touch-controls="true"] body:has(#mobile-controls[data-open="true"]) #camera-button,
 html[data-touch-controls="true"] body:has(#mobile-controls[data-open="true"]) #wave-button,
 html[data-touch-controls="true"] body:has(#mobile-controls[data-open="true"]) #bubble-button,
 html[data-touch-controls="true"] body:has(#mobile-controls[data-open="true"]) #foam-button,
@@ -1256,6 +1273,7 @@ html[data-touch-controls="true"] body[data-intro-visible="true"] #online-indicat
 html[data-touch-controls="true"] body[data-intro-visible="true"] #breakdance-button,
 html[data-touch-controls="true"] body[data-intro-visible="true"] #sunglasses-button,
 html[data-touch-controls="true"] body[data-intro-visible="true"] #perspective-button,
+html[data-touch-controls="true"] body[data-intro-visible="true"] #camera-button,
 html[data-touch-controls="true"] body[data-intro-visible="true"] #wave-button,
 html[data-touch-controls="true"] body[data-intro-visible="true"] #bubble-button,
 html[data-touch-controls="true"] body[data-intro-visible="true"] #foam-button,


### PR DESCRIPTION
Yo 🦍🍌

## Context

I had a bit of trouble moving in the game for two reasons:
- keeping the mouse clicked to move the camera isn't super practical
- I have a french keyboard, so WASD layout for me is ZQSD

## Summary

- Add a pointer-lock free mouse camera mode with Escape exit handling:
  - Accessible via a new Camera control: "F" keypress in WASD/ZQSD, "O" keypress in IJKL, or 🖱️ button toggles free mouse vs click-drag camera.
  - Press "esc" key, the Camera shortcut, or the 🖱️ button again to escape this mode.
  - That way the camera handles like a 3rd person 3D game would (no need to click).
- Add a ZQSD/AZERTY movement layout alongside WASD and IJKL.

NB: it's not great in tight spaces

## Test plan
- [x] bun run build
- [x] Manually verify T toggles TP/FP, F/O toggles free mouse/click-drag depending on layout, and Escape exits free mouse.