### PR TITLE
Jetpack accessory

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -20,6 +20,9 @@ import {
 } from './src/graffiti.ts'
 import { photoWallThumbnailHeight, photoWallThumbnailWidth } from './src/photo-wall-data.ts'
 import {
+  ACTION_BUBBLING,
+  ACTION_FOAMING,
+  ACTION_JETPACK,
   ACTIONS,
   ADMIN,
   BEACH_BALLS,
@@ -85,6 +88,8 @@ import type { DuckPose } from './src/duck-position.ts'
 import { outsideBounds, outsideRooftop, outsideTreeStart, roomBounds, upstairsWallHeight, videoPlaylists } from './src/scene-data.ts'
 import { resolveDuckPosition, roomAt, seatAt } from './src/scene.ts'
 import type { GraffitiSplat, Vec3, VideoZone } from './src/types.ts'
+
+const allowedActionMask = ACTION_BUBBLING | ACTION_FOAMING | ACTION_JETPACK
 
 type Client = {
   id: number
@@ -524,7 +529,7 @@ const server = Bun.serve<SocketData>({
           touchInteraction(client)
           broadcast(client, encodeServerActions({
             id: client.id,
-            actions: actions.actions & 0b11,
+            actions: actions.actions & allowedActionMask,
             angle: actions.angle,
           }))
           return

--- a/src/camera-controller.ts
+++ b/src/camera-controller.ts
@@ -41,7 +41,11 @@ type CameraBasis = {
   upZ: number
 }
 
-export function createCameraController(canvas: HTMLCanvasElement, characterPosition: Vec3) {
+export function createCameraController(
+  canvas: HTMLCanvasElement,
+  characterPosition: Vec3,
+  options: { suppressManualDrag?: () => boolean } = {},
+) {
   const position: Vec3 = [-2.2, 0.15, -9.0]
   const target: Vec3 = [-2.2, -0.75, -6.8]
   const viewUp: Vec3 = [0, 1, 0]
@@ -155,7 +159,7 @@ export function createCameraController(canvas: HTMLCanvasElement, characterPosit
 
   canvas.style.touchAction = 'none'
   canvas.addEventListener('pointerdown', event => {
-    if (event.pointerType === 'mouse') {
+    if (event.pointerType === 'mouse' || options.suppressManualDrag?.()) {
       return
     }
 
@@ -224,7 +228,7 @@ export function createCameraController(canvas: HTMLCanvasElement, characterPosit
   })
 
   document.addEventListener('mousedown', event => {
-    if (freeMouse || event.button !== 0 || interactiveTarget(event.target)) {
+    if (freeMouse || event.button !== 0 || interactiveTarget(event.target) || options.suppressManualDrag?.()) {
       return
     }
 

--- a/src/character-draw.ts
+++ b/src/character-draw.ts
@@ -15,8 +15,8 @@ import { resolvePlayerStyle } from './character-style.ts'
 import { characterView, characterVisibilityInto } from './character-visibility.ts'
 import { raiseCigaretteArm, setCigaretteGeometry } from './cigarette.ts'
 import type { CigaretteGeometry } from './cigarette.ts'
-import { clamp, normalizeIndex } from './math.ts'
-import { roomAt } from './scene.ts'
+import { clamp, lengthSq, normalizeIndex } from './math.ts'
+import { roomAt, walkHeight, walkLoftHeight } from './scene.ts'
 import { createObjectTurnBasisCache } from './turn-basis.ts'
 import type {
   CharacterLight,
@@ -36,11 +36,13 @@ type CharacterInput = {
   position: Vec3
   turn: number
   motionBlend: number
+  input?: Vec3
   mode?: CharacterMode
   modeTime?: number
   poseUp?: Vec3
   hideHead?: boolean
   sunglasses?: boolean
+  jetpacking?: boolean
   idleClipIndex: number
   style: PlayerStyle
   resolvedStyle?: ResolvedPlayerStyle
@@ -52,6 +54,7 @@ type BuildOptions = {
   character: CharacterInput
   hairMeshes: HairMesh[]
   light: CharacterLight
+  loft?: boolean
   players: Player[]
   rig: CharacterRig
   time: number
@@ -106,6 +109,10 @@ const leftUpLegIndex = poseJointIndices.get('mixamorig:LeftUpLeg')!
 const rightUpLegIndex = poseJointIndices.get('mixamorig:RightUpLeg')!
 const leftLegIndex = poseJointIndices.get('mixamorig:LeftLeg')!
 const rightLegIndex = poseJointIndices.get('mixamorig:RightLeg')!
+const leftFootIndex = poseJointIndices.get('mixamorig:LeftFoot')!
+const rightFootIndex = poseJointIndices.get('mixamorig:RightFoot')!
+const leftToeIndex = poseJointIndices.get('mixamorig:LeftToe_End')!
+const rightToeIndex = poseJointIndices.get('mixamorig:RightToe_End')!
 const headIndex = poseJointIndices.get('mixamorig:Head')!
 const headTopIndex = poseJointIndices.get('mixamorig:HeadTop_End')!
 
@@ -159,6 +166,21 @@ const sprayCanCapA: Vec3 = [0, 0, 0]
 const sprayCanCapB: Vec3 = [0, 0, 0]
 const sprayCanNozzleA: Vec3 = [0, 0, 0]
 const sprayCanNozzleB: Vec3 = [0, 0, 0]
+const jetpackBodyA: Vec3 = [0, 0, 0]
+const jetpackBodyB: Vec3 = [0, 0, 0]
+const jetpackNozzleA: Vec3 = [0, 0, 0]
+const jetpackNozzleB: Vec3 = [0, 0, 0]
+const jetpackNozzleGlowA: Vec3 = [0, 0, 0]
+const jetpackNozzleGlowB: Vec3 = [0, 0, 0]
+const jetpackHandleA: Vec3 = [0, 0, 0]
+const jetpackHandleB: Vec3 = [0, 0, 0]
+const jetpackAxis: Vec3 = [0, 1, 0]
+const jetpackSide: Vec3 = [1, 0, 0]
+const jetpackBack: Vec3 = [0, 0, -1]
+const jetpackNozzleColor: Vec3 = [0.08, 0.085, 0.1]
+const jetpackNozzleGlow: Vec3 = [1, 0.32, 0.04]
+const jetpackHandleColor: Vec3 = [0.035, 0.04, 0.055]
+const jetpackHandleForearmEnd = 1.22
 const sunglassesA: Vec3 = [0, 0, 0]
 const sunglassesB: Vec3 = [0, 0, 0]
 const sunglassesLens: Vec3 = [0.035, 0.018, 0.01]
@@ -388,6 +410,10 @@ function addRenderedCharacter(
   if (renderAccessory && style.accessoryKind === 'cigarette') {
     raisePoseCigaretteArm(pose, turn, options.time)
   }
+  else if (renderAccessory && style.accessoryKind === 'jetpack') {
+    setJetpackArmPose(pose, turn)
+  }
+  setAirborneLegInertia(pose, player, turn, options.loft === true)
 
   for (const part of characterPartPlans) {
     if ((style.bottomMode === 'pants' || !part.part.bottom) && (!hideHead || part.toIndex !== headTopIndex)) {
@@ -409,6 +435,9 @@ function addRenderedCharacter(
     }
     else if (style.accessoryKind === 'cigarette') {
       addCigarette(target, boxInstances, pose, player, turn, style, options.light, localReflection, options.time)
+    }
+    else if (style.accessoryKind === 'jetpack') {
+      addJetpack(target, boxInstances, pose, player, turn, style, options.light, localReflection)
     }
     else {
       addSprayCan(target, boxInstances, pose, player, turn, style, options.light, localReflection)
@@ -552,7 +581,7 @@ function addGlowsticks(
   target: VertexWriter,
   boxInstances: VertexWriter,
   pose: Vec3[],
-  player: { turn: number },
+  player: { jetpacking?: boolean; turn: number },
   turn: TurnBasis,
   style: ResolvedPlayerStyle,
   light: CharacterLight,
@@ -679,6 +708,219 @@ function addSprayCanAtHand(
   sprayCanNozzleB[2] = centerZ + sideZ * handSide * 0.13
   addCharacterBox(target, boxInstances, sprayCanNozzleA, sprayCanNozzleB, 0.035, 0.035, color, 0.12, player.turn,
     localReflection, light, 0, turn.sin, turn.cos, { side: sprayCanNozzleSide })
+}
+
+function addJetpack(
+  target: VertexWriter,
+  boxInstances: VertexWriter,
+  pose: Vec3[],
+  player: { jetpacking?: boolean; turn: number },
+  turn: TurnBasis,
+  style: ResolvedPlayerStyle,
+  light: CharacterLight,
+  localReflection: boolean,
+) {
+  setJetpackReferenceBox(pose, turn)
+  addCharacterBox(target, boxInstances, jetpackBodyA, jetpackBodyB, 0.26, 0.13, style.accessory!, 0.08,
+    player.turn, localReflection, light, 0, turn.sin, turn.cos, { side: jetpackSide })
+  addJetpackNozzle(target, boxInstances, pose, player, turn, light, localReflection, -0.075, player.jetpacking === true)
+  addJetpackNozzle(target, boxInstances, pose, player, turn, light, localReflection, 0.075, player.jetpacking === true)
+  addJetpackHandle(target, boxInstances, pose, player, turn, light, localReflection, -0.2,
+    pose[rightForeArmIndex]!, pose[rightHandIndex]!)
+  addJetpackHandle(target, boxInstances, pose, player, turn, light, localReflection, 0.2,
+    pose[leftForeArmIndex]!, pose[leftHandIndex]!)
+}
+
+function addJetpackNozzle(
+  target: VertexWriter,
+  boxInstances: VertexWriter,
+  pose: Vec3[],
+  player: { turn: number },
+  turn: TurnBasis,
+  light: CharacterLight,
+  localReflection: boolean,
+  sideOffset: number,
+  active: boolean,
+) {
+  setJetpackBoxPoint(jetpackNozzleA, sideOffset, 0.02, 0.02)
+  setJetpackBoxPoint(jetpackNozzleB, sideOffset, -0.03, 0.02)
+  addCharacterBox(target, boxInstances, jetpackNozzleA, jetpackNozzleB, 0.055, 0.06, jetpackNozzleColor, 0.18,
+    player.turn, localReflection, light, 0, turn.sin, turn.cos, { side: jetpackSide })
+  setJetpackBoxPoint(jetpackNozzleGlowA, sideOffset, -0.025, 0.02)
+  setJetpackBoxPoint(jetpackNozzleGlowB, sideOffset, -0.055, 0.02)
+  addCharacterBox(target, boxInstances, jetpackNozzleGlowA, jetpackNozzleGlowB, 0.065, 0.07, jetpackNozzleGlow,
+    active ? 1.6 : 0.38,
+    player.turn, localReflection, light, 0, turn.sin, turn.cos, { side: jetpackSide })
+}
+
+function addJetpackHandle(
+  target: VertexWriter,
+  boxInstances: VertexWriter,
+  pose: Vec3[],
+  player: { turn: number },
+  turn: TurnBasis,
+  light: CharacterLight,
+  localReflection: boolean,
+  sideOffset: number,
+  elbow: Vec3,
+  hand: Vec3,
+) {
+  const sideSign = Math.sign(sideOffset)
+  const endSideSpread = 0.08
+
+  setJetpackPoint(jetpackHandleA, pose, turn, sideOffset, 0.3, 0.17)
+  jetpackHandleB[0] = elbow[0]
+  jetpackHandleB[1] = elbow[1]
+  jetpackHandleB[2] = elbow[2]
+  addCharacterBox(target, boxInstances, jetpackHandleA, jetpackHandleB, 0.026, 0.026, jetpackHandleColor, 0.12,
+    player.turn, localReflection, light, 0, turn.sin, turn.cos, { side: jetpackSide })
+
+  jetpackHandleA[0] = elbow[0]
+  jetpackHandleA[1] = elbow[1] - 0.055
+  jetpackHandleA[2] = elbow[2]
+  jetpackHandleB[0] = elbow[0] + (hand[0] - elbow[0]) * jetpackHandleForearmEnd + turn.cos * sideSign * endSideSpread
+  jetpackHandleB[1] = elbow[1] + (hand[1] - elbow[1]) * jetpackHandleForearmEnd - 0.015
+  jetpackHandleB[2] = elbow[2] + (hand[2] - elbow[2]) * jetpackHandleForearmEnd - turn.sin * sideSign * endSideSpread
+  addCharacterBox(target, boxInstances, jetpackHandleA, jetpackHandleB, 0.026, 0.026, jetpackHandleColor, 0.12,
+    player.turn, localReflection, light, 0, turn.sin, turn.cos, { side: jetpackSide })
+}
+
+export function setPoseJetpackNozzles(left: Vec3, right: Vec3, pose: Vec3[], turn: TurnBasis) {
+  setJetpackReferenceBox(pose, turn)
+  setJetpackBoxPoint(left, -0.075, -0.055, 0.02)
+  setJetpackBoxPoint(right, 0.075, -0.055, 0.02)
+}
+
+function setJetpackReferenceBox(pose: Vec3[], turn: TurnBasis) {
+  setJetpackPoint(jetpackBodyA, pose, turn, 0, -0.34, 0.17)
+  setJetpackPoint(jetpackBodyB, pose, turn, 0, 1.1, 0.17)
+  setJetpackSide(jetpackSide, turn)
+  setJetpackFrame()
+}
+
+function setJetpackBoxPoint(target: Vec3, side: number, along: number, back: number) {
+  target[0] = jetpackBodyA[0] + jetpackAxis[0] * along + jetpackSide[0] * side + jetpackBack[0] * back
+  target[1] = jetpackBodyA[1] + jetpackAxis[1] * along + jetpackSide[1] * side + jetpackBack[1] * back
+  target[2] = jetpackBodyA[2] + jetpackAxis[2] * along + jetpackSide[2] * side + jetpackBack[2] * back
+}
+
+function setJetpackFrame() {
+  const axisX = jetpackBodyB[0] - jetpackBodyA[0]
+  const axisY = jetpackBodyB[1] - jetpackBodyA[1]
+  const axisZ = jetpackBodyB[2] - jetpackBodyA[2]
+  const axisLength = Math.sqrt(axisX * axisX + axisY * axisY + axisZ * axisZ)
+
+  jetpackAxis[0] = axisX / axisLength
+  jetpackAxis[1] = axisY / axisLength
+  jetpackAxis[2] = axisZ / axisLength
+
+  const sideDotAxis = jetpackSide[0] * jetpackAxis[0] + jetpackSide[1] * jetpackAxis[1]
+    + jetpackSide[2] * jetpackAxis[2]
+
+  jetpackSide[0] -= jetpackAxis[0] * sideDotAxis
+  jetpackSide[1] -= jetpackAxis[1] * sideDotAxis
+  jetpackSide[2] -= jetpackAxis[2] * sideDotAxis
+
+  const sideLength = Math.sqrt(jetpackSide[0] * jetpackSide[0] + jetpackSide[1] * jetpackSide[1]
+    + jetpackSide[2] * jetpackSide[2])
+
+  jetpackSide[0] /= sideLength
+  jetpackSide[1] /= sideLength
+  jetpackSide[2] /= sideLength
+  jetpackBack[0] = jetpackAxis[1] * jetpackSide[2] - jetpackAxis[2] * jetpackSide[1]
+  jetpackBack[1] = jetpackAxis[2] * jetpackSide[0] - jetpackAxis[0] * jetpackSide[2]
+  jetpackBack[2] = jetpackAxis[0] * jetpackSide[1] - jetpackAxis[1] * jetpackSide[0]
+}
+
+function setJetpackPoint(target: Vec3, pose: Vec3[], turn: TurnBasis, side: number, lift: number, back: number) {
+  const spine = pose[spine2Index]!
+  const neck = pose[neckIndex]!
+  const torsoX = neck[0] - spine[0]
+  const torsoY = neck[1] - spine[1]
+  const torsoZ = neck[2] - spine[2]
+  const sideX = turn.cos
+  const sideZ = -turn.sin
+  const backX = -turn.sin
+  const backZ = -turn.cos
+
+  target[0] = spine[0] + torsoX * lift + sideX * side + backX * back
+  target[1] = spine[1] + torsoY * lift
+  target[2] = spine[2] + torsoZ * lift + sideZ * side + backZ * back
+}
+
+function setJetpackSide(target: Vec3, turn: TurnBasis) {
+  target[0] = turn.cos
+  target[1] = 0
+  target[2] = -turn.sin
+}
+
+function setJetpackArmPose(pose: Vec3[], turn: TurnBasis) {
+  setJetpackArmSide(pose[leftArmIndex]!, pose[leftForeArmIndex]!, pose[leftHandIndex]!, turn, 1)
+  setJetpackArmSide(pose[rightArmIndex]!, pose[rightForeArmIndex]!, pose[rightHandIndex]!, turn, -1)
+}
+
+function setJetpackArmSide(shoulder: Vec3, elbow: Vec3, hand: Vec3, turn: TurnBasis, sign: -1 | 1) {
+  const upperLength = distance(shoulder, elbow)
+  const foreArmLength = distance(elbow, hand)
+  const sideX = turn.cos * sign
+  const sideZ = -turn.sin * sign
+  const forwardX = turn.sin
+  const forwardZ = turn.cos
+
+  elbow[0] = shoulder[0] + sideX * 0.02
+  elbow[1] = shoulder[1] - upperLength
+  elbow[2] = shoulder[2] + sideZ * 0.02
+  hand[0] = elbow[0] + forwardX * foreArmLength
+  hand[1] = elbow[1]
+  hand[2] = elbow[2] + forwardZ * foreArmLength
+}
+
+function setAirborneLegInertia(pose: Vec3[], player: CharacterInput, turn: TurnBasis, loft: boolean) {
+  if (player.mode === 'jump' || !player.input || lengthSq(player.input) === 0) {
+    return
+  }
+
+  const floorY = loft
+    ? walkLoftHeight(player.position[0], player.position[1], player.position[2])
+    : walkHeight(player.position[0], player.position[1], player.position[2])
+
+  if (player.position[1] <= floorY + 0.035) {
+    return
+  }
+
+  const backX = -turn.sin
+  const backZ = -turn.cos
+
+  setAirborneLegSide(pose[leftUpLegIndex]!, pose[leftLegIndex]!, pose[leftFootIndex]!, pose[leftToeIndex]!, backX, backZ)
+  setAirborneLegSide(pose[rightUpLegIndex]!, pose[rightLegIndex]!, pose[rightFootIndex]!, pose[rightToeIndex]!, backX,
+    backZ)
+}
+
+function setAirborneLegSide(hip: Vec3, knee: Vec3, foot: Vec3, toe: Vec3, backX: number, backZ: number) {
+  const upperLength = distance(hip, knee)
+  const lowerLength = distance(knee, foot)
+  const footLength = distance(foot, toe)
+  const kneeBack = Math.min(0.12, upperLength * 0.45)
+  const footBack = Math.min(0.18, lowerLength * 0.55)
+  const toeForward = Math.min(0.07, footLength * 0.75)
+
+  knee[0] = hip[0] + backX * kneeBack
+  knee[1] = hip[1] - Math.sqrt(Math.max(0, upperLength * upperLength - kneeBack * kneeBack))
+  knee[2] = hip[2] + backZ * kneeBack
+  foot[0] = knee[0] + backX * footBack
+  foot[1] = knee[1] - Math.sqrt(Math.max(0, lowerLength * lowerLength - footBack * footBack))
+  foot[2] = knee[2] + backZ * footBack
+  toe[0] = foot[0] - backX * toeForward
+  toe[1] = foot[1] - Math.sqrt(Math.max(0, footLength * footLength - toeForward * toeForward))
+  toe[2] = foot[2] - backZ * toeForward
+}
+
+function distance(a: Vec3, b: Vec3) {
+  const dx = b[0] - a[0]
+  const dy = b[1] - a[1]
+  const dz = b[2] - a[2]
+
+  return Math.sqrt(dx * dx + dy * dy + dz * dz)
 }
 
 export function raisePoseCigaretteArm(pose: Vec3[], turn: TurnBasis, time: number) {

--- a/src/character-render-system.ts
+++ b/src/character-render-system.ts
@@ -9,6 +9,7 @@ import {
   buildCharacterDrawData,
   characterHeadBasisInto,
   headPoseIndex,
+  setPoseJetpackNozzles,
   setPoseCigaretteGeometry,
 } from './character-draw.ts'
 import type { CharacterDrawCache, CharacterHeadBasis } from './character-draw.ts'
@@ -51,7 +52,9 @@ export function createCharacterRenderSystem(options: {
   gl: WebGL2RenderingContext
   hairController: ReturnType<typeof createCharacterHairController>
   idleClipIndex: () => number
+  jetpacking?: () => boolean
   light: CharacterLight
+  loft?: () => boolean
   localCharacter: ReturnType<typeof createLocalCharacter>
   localPoseUp?: () => Vec3 | undefined
   players: Player[]
@@ -170,11 +173,13 @@ export function createCharacterRenderSystem(options: {
         position: options.characterPosition,
         turn: options.localCharacter.turn,
         motionBlend: options.localCharacter.motionBlend,
+        input: options.localCharacter.input,
         mode: options.localCharacter.mode,
         modeTime: options.localCharacter.modeTime,
         poseUp: options.localPoseUp?.(),
         hideHead: options.camera.firstPerson,
         sunglasses: options.sunglasses(),
+        jetpacking: options.jetpacking?.() === true,
         idleClipIndex: options.idleClipIndex(),
         style: {
           topStyleIndex: options.styleController.topStyleIndex,
@@ -188,6 +193,7 @@ export function createCharacterRenderSystem(options: {
       hairMeshes: options.hairController.meshes,
       height: options.canvas.height,
       light: options.light,
+      loft: options.loft?.() === true,
       players: renderPlayers ? options.players : [],
       rig: activeRig,
       time,
@@ -250,6 +256,18 @@ export function createCharacterRenderSystem(options: {
     return true
   }
 
+  function setJetpackNozzles(player: CigarettePoseInput, time: number, left: Vec3, right: Vec3) {
+    if (!rig) {
+      return false
+    }
+
+    const turn = cigaretteTurnBasis(player, player.turn)
+
+    setPoseJetpackNozzles(left, right, sampleCigarettePose(rig, player, time), turn)
+
+    return true
+  }
+
   function sampleCigarettePose(activeRig: CharacterRig, player: CigarettePoseInput, time: number) {
     const includeRun = player.motionBlend > 0 || player.mode === 'wave' || player.mode === 'waveOut'
 
@@ -290,6 +308,7 @@ export function createCharacterRenderSystem(options: {
     loadRemainingDancesIdle,
     setCigaretteMouth,
     setCigaretteTip,
+    setJetpackNozzles,
     update,
   }
 }

--- a/src/character-style.ts
+++ b/src/character-style.ts
@@ -19,7 +19,10 @@ export const sprayColors: Vec3[] = graffitiColors
 export const cigaretteColors: Vec3[] = [
   [0.96, 0.96, 0.92],
 ]
-export const accessoryPalette: Vec3[] = [...glowstickColors, ...sprayColors, ...cigaretteColors]
+export const jetpackColors: Vec3[] = [
+  [0.23, 0.25, 0.3],
+]
+export const accessoryPalette: Vec3[] = [...glowstickColors, ...sprayColors, ...cigaretteColors, ...jetpackColors]
 
 export function resolveAccessoryKind(accessoryIndex: number): ResolvedPlayerStyle['accessoryKind'] {
   const index = normalizeIndex(accessoryIndex, accessoryPalette.length + 1)
@@ -30,7 +33,9 @@ export function resolveAccessoryKind(accessoryIndex: number): ResolvedPlayerStyl
     ? 'glowstick'
     : index <= glowstickColors.length + sprayColors.length
     ? 'spray'
-    : 'cigarette'
+    : index <= glowstickColors.length + sprayColors.length + cigaretteColors.length
+    ? 'cigarette'
+    : 'jetpack'
 }
 
 export function createCharacterStyleController() {

--- a/src/club-app.ts
+++ b/src/club-app.ts
@@ -37,7 +37,7 @@ import { createMultiplayer, updateRemotePlayers } from './multiplayer.ts'
 import { createPlayers, takeNpcSeat, updatePlayers } from './player-system.ts'
 import type { ProjectedPoint, Viewport, WallProjector } from './projection.ts'
 import { createWallProjector, projectWallPointInto, projectWallPointWithMinDepthInto } from './projection.ts'
-import { ACTION_BUBBLING, ACTION_FOAMING, instagramMaxLength } from './protocol.ts'
+import { ACTION_BUBBLING, ACTION_FOAMING, ACTION_JETPACK, instagramMaxLength } from './protocol.ts'
 import type { GraffitiSnapshot, MessagePacket, VideoEndedEntry } from './protocol.ts'
 import { emojiReactionFromMessage, pickerEmojis, reactionEmojis } from './reactions.ts'
 import {
@@ -152,7 +152,7 @@ import { getDomElements } from './dom-elements.ts'
 import { createHelpUi } from './help-ui.ts'
 import { createInstagramLink } from './instagram-link.ts'
 import { createIntroEffect } from './intro-effect.ts'
-import { createLocalCharacter } from './local-character.ts'
+import { createLocalCharacter, jetpackMaxEffectiveHeight } from './local-character.ts'
 import { createMobileControls } from './mobile-controls.ts'
 import { createPhotoWallRenderer } from './photo-wall-renderer.ts'
 import type { Photo } from './photo-wall-ui.ts'
@@ -365,7 +365,10 @@ const photoWallUi = createPhotoWallUi(photoWall, {
 const scheduleWallUi = createScheduleWallUi(scheduleWall)
 const helpUi = createHelpUi()
 const helpSeen = localStorage.getItem(helpSeenKey) === 'true'
-const cameraController = createCameraController(canvas, characterPosition)
+let suppressManualCameraDrag = false
+const cameraController = createCameraController(canvas, characterPosition, {
+  suppressManualDrag: () => suppressManualCameraDrag,
+})
 let arcadeReady = true
 const arcadeUi = createArcadeUi({
   onClose: exitArcadeMode,
@@ -2480,9 +2483,26 @@ const smokeBufferCache: NumberBufferCache = { data: smokeWriter.data }
 const smokeTip: Vec3 = [0, 0, 0]
 const smokeMouth: Vec3 = [0, 0, 0]
 const smokeForward: Vec3 = [0, 0, 0]
+const jetpackLeftNozzle: Vec3 = [0, 0, 0]
+const jetpackRightNozzle: Vec3 = [0, 0, 0]
+const jetpackDown: Vec3 = [0, 0, 0]
+const jetpackSparkColors: Vec3[] = [
+  [1, 0.18, 0.02],
+  [1, 0.18, 0.02],
+  [1, 0.18, 0.02],
+  [1, 0.18, 0.02],
+  [1, 0.52, 0.04],
+  [1, 0.52, 0.04],
+  [1, 0.86, 0.12],
+]
 const smokeInterval = 900
 const smokeHeldInterval = 80
 const smokeExhaleInterval = 45
+const jetpackIdleSmokeInterval = 220
+const jetpackThrustSmokeInterval = 18
+const jetpackSparkInterval = 45
+const jetpackSputterSmokeInterval = 160
+const jetpackSputterSparkInterval = 80
 const smokeMachineIntervalMin = 120_000
 const smokeMachineIntervalMax = 420_000
 const smokeMachineSchedulePeriod = 604_800_000
@@ -2497,7 +2517,16 @@ let smokeMachineScheduleAnchor = 0
 let nextSmokeMachineBurstAt = 0
 let smokeMachineBurstUntil = 0
 let nextSmokeMachineEmitStamp = 0
-type ParticleTimers = { bubble: number; foam: number; smokeWisp: number; smokeHeld: number; smokeExhale: number }
+type ParticleTimers = {
+  bubble: number
+  foam: number
+  jetpackIdle: number
+  jetpackSpark: number
+  jetpackThrust: number
+  smokeWisp: number
+  smokeHeld: number
+  smokeExhale: number
+}
 type ParticlePlayer = {
   position: Vec3
   turn: number
@@ -2525,6 +2554,8 @@ let nextRemoteSeatSyncAt = 0
 let graffitiSeed = Math.floor(Math.random() * 65536)
 let lastSprayAt = 0
 let sprayPointer = 0
+let jetpackPointer = 0
+let jetpackThrust = false
 const sprayInterval = 55
 const graffitiPaintChunk = 25
 const graffitiAppendQueue: GraffitiSplat[] = []
@@ -2537,6 +2568,14 @@ let graffitiTextureRenderPending = false
 let graffitiSnapshotMaxId = 0
 
 renderGraffitiTexture([])
+
+function localJetpackEquipped() {
+  return resolveAccessoryKind(styleController.accessoryIndex) === 'jetpack'
+}
+
+function localJetpackActionActive() {
+  return jetpackThrust && localJetpackEquipped()
+}
 
 function resetServerState() {
   predictedMessages.clear()
@@ -2564,7 +2603,8 @@ function connectMultiplayer(spaceSlug?: string) {
     localMode: () => localCharacter.mode,
     localIdleClipIndex: () => idleClipIndex,
     localSunglasses: () => sunglasses,
-    localActions: () => (bubbling ? ACTION_BUBBLING : 0) | (foaming ? ACTION_FOAMING : 0),
+    localActions: () => (bubbling ? ACTION_BUBBLING : 0) | (foaming ? ACTION_FOAMING : 0)
+      | (localJetpackActionActive() ? ACTION_JETPACK : 0),
     localActionTurn: () => cameraController.turn,
     localInstagram: () => instagram,
     localNickname: () => nickname,
@@ -3413,6 +3453,35 @@ document.addEventListener('pointerdown', event => {
 canvas.addEventListener('contextmenu', event => event.preventDefault())
 
 canvas.addEventListener('pointerdown', event => {
+  if (!introHidden || jetpackPointer !== 0) {
+    return
+  }
+
+  if (event.pointerType === 'mouse' && event.button !== 0) {
+    return
+  }
+
+  if (!localJetpackEquipped()) {
+    return
+  }
+
+  event.preventDefault()
+  event.stopImmediatePropagation()
+  jetpackPointer = event.pointerId
+  jetpackThrust = true
+  suppressManualCameraDrag = true
+  try {
+    canvas.setPointerCapture(event.pointerId)
+  }
+  catch {
+    // Some browsers can reject capture if the pointer is no longer active.
+  }
+  if (hasMultiplayer) {
+    multiplayer.sendActionsIfChanged()
+  }
+}, { capture: true })
+
+canvas.addEventListener('pointerdown', event => {
   if (appSpace.kind === 'loft') {
     return
   }
@@ -3462,6 +3531,39 @@ canvas.addEventListener('pointercancel', event => {
     canvas.releasePointerCapture(event.pointerId)
   }
 }, { capture: true })
+
+function stopJetpackThrust(pointerId = jetpackPointer) {
+  if (pointerId !== jetpackPointer) {
+    return
+  }
+
+  jetpackPointer = 0
+  jetpackThrust = false
+  suppressManualCameraDrag = false
+  if (canvas.hasPointerCapture(pointerId)) {
+    try {
+      canvas.releasePointerCapture(pointerId)
+    }
+    catch {
+      // Ignore stale captures; the state above is the source of truth.
+    }
+  }
+  if (hasMultiplayer) {
+    multiplayer.sendActionsIfChanged()
+  }
+}
+
+for (const eventName of ['pointerup', 'pointercancel', 'lostpointercapture'] as const) {
+  canvas.addEventListener(eventName, event => {
+    stopJetpackThrust(event.pointerId)
+  }, { capture: true })
+}
+
+for (const eventName of ['pointerup', 'pointercancel'] as const) {
+  document.addEventListener(eventName, event => {
+    stopJetpackThrust(event.pointerId)
+  }, { capture: true })
+}
 
 function sprayAt(clientX: number, clientY: number) {
   if (appSpace.kind === 'loft') {
@@ -4235,7 +4337,15 @@ const draw = (stamp: number) => {
       treeSwingControl()) || treeSwingGeometryDirty
   }
 
-  localCharacter.update(delta, cameraController.turn, outsideTree, styleController.bottomMode, inLoft, occupiedSeats,
+  const jetpackEquipped = localJetpackEquipped()
+
+  if (jetpackThrust && !jetpackEquipped) {
+    stopJetpackThrust()
+  }
+  const jetpackEffective = jetpackThrust && jetpackEquipped && characterPosition[1] < jetpackMaxEffectiveHeight
+
+  localCharacter.update(delta, cameraController.turn, outsideTree, styleController.bottomMode,
+    jetpackEffective, inLoft, occupiedSeats,
     seat => takeNpcSeat(npcPlayers, seat, stamp * 0.001, outsideTree, occupiedSeats))
   if (isAtLoftExitDoor()) {
     enterMain(true)
@@ -4283,10 +4393,12 @@ const draw = (stamp: number) => {
   localParticlePlayer.modeTime = localCharacter.modeTime
   localParticlePlayer.idleClipIndex = idleClipIndex
   emitPlayerParticles(localParticleSource, localParticlePlayer, stamp, bubbling, foaming,
-    introHidden && resolveAccessoryKind(styleController.accessoryIndex) === 'cigarette')
+    introHidden && resolveAccessoryKind(styleController.accessoryIndex) === 'cigarette', introHidden && jetpackEquipped,
+    localJetpackActionActive())
   for (const [id, player] of multiplayer.players) {
     emitPlayerParticles(id, player, stamp, player.bubbling ?? false, player.foaming ?? false,
-      resolveAccessoryKind(player.style.accessoryIndex) === 'cigarette')
+      resolveAccessoryKind(player.style.accessoryIndex) === 'cigarette',
+      resolveAccessoryKind(player.style.accessoryIndex) === 'jetpack', player.jetpacking ?? false)
   }
   updateSmokeMachines(stamp)
   bubbleSystem.update(delta)
@@ -4466,8 +4578,10 @@ function emitPlayerParticles(
   isBubbling: boolean,
   isFoaming: boolean,
   isSmoking: boolean,
+  hasJetpack: boolean,
+  isJetpacking: boolean,
 ) {
-  if (!isBubbling && !isFoaming && !isSmoking) {
+  if (!isBubbling && !isFoaming && !isSmoking && !hasJetpack) {
     particleTimers.delete(source)
     return
   }
@@ -4475,7 +4589,16 @@ function emitPlayerParticles(
   let timers = particleTimers.get(source)
 
   if (!timers) {
-    timers = { bubble: 0, foam: 0, smokeWisp: 0, smokeHeld: 0, smokeExhale: 0 }
+    timers = {
+      bubble: 0,
+      foam: 0,
+      jetpackIdle: 0,
+      jetpackSpark: 0,
+      jetpackThrust: 0,
+      smokeWisp: 0,
+      smokeHeld: 0,
+      smokeExhale: 0,
+    }
     particleTimers.set(source, timers)
   }
 
@@ -4538,6 +4661,102 @@ function emitPlayerParticles(
       smokeSystem.emit(smokeMouth, smokeForward, { count: 1 + Math.floor(exhale * 3), exhale: true })
     }
   }
+
+  if (hasJetpack) {
+    const time = stamp * 0.001
+
+    if (characterRenderSystem.setJetpackNozzles(player, time, jetpackLeftNozzle, jetpackRightNozzle)) {
+      if (isJetpacking) {
+        if (player.position[1] >= jetpackMaxEffectiveHeight) {
+          emitJetpackSputter(stamp, timers)
+        }
+        else {
+          emitJetpackThrust(stamp, timers)
+        }
+      }
+      else {
+        emitJetpackIdle(stamp, timers)
+      }
+    }
+  }
+}
+
+function emitJetpackIdle(stamp: number, timers: ParticleTimers) {
+  if (stamp < timers.jetpackIdle) {
+    return
+  }
+
+  timers.jetpackIdle = stamp + jetpackIdleSmokeInterval
+  emitJetpackSmoke(jetpackLeftNozzle, false)
+  emitJetpackSmoke(jetpackRightNozzle, false)
+}
+
+function emitJetpackThrust(stamp: number, timers: ParticleTimers) {
+  if (stamp >= timers.jetpackThrust) {
+    timers.jetpackThrust = stamp + jetpackThrustSmokeInterval
+    emitJetpackSmoke(jetpackLeftNozzle, true)
+    emitJetpackSmoke(jetpackRightNozzle, true)
+  }
+
+  if (stamp >= timers.jetpackSpark) {
+    timers.jetpackSpark = stamp + jetpackSparkInterval
+    emitJetpackSpark(jetpackLeftNozzle)
+    emitJetpackSpark(jetpackRightNozzle)
+  }
+}
+
+function emitJetpackSputter(stamp: number, timers: ParticleTimers) {
+  if (stamp >= timers.jetpackThrust) {
+    timers.jetpackThrust = stamp + jetpackSputterSmokeInterval
+    emitJetpackSmoke(jetpackLeftNozzle, false)
+    emitJetpackSmoke(jetpackRightNozzle, false)
+  }
+
+  if (stamp >= timers.jetpackSpark) {
+    timers.jetpackSpark = stamp + jetpackSputterSparkInterval
+    emitJetpackSpark(jetpackLeftNozzle)
+    emitJetpackSpark(jetpackRightNozzle)
+  }
+}
+
+function emitJetpackSmoke(origin: Vec3, active: boolean) {
+  smokeSystem.emit(origin, jetpackDown, active
+    ? {
+      count: 4,
+      growthScale: 1.2,
+      lifeScale: 0.28,
+      originSpread: 0.045,
+      radiusScale: 0.78,
+      rise: -1.25,
+      speed: 0,
+      velocitySpread: 0.06,
+    }
+    : {
+      count: 1,
+      growthScale: 0.7,
+      lifeScale: 0.22,
+      originSpread: 0.025,
+      radiusScale: 0.34,
+      rise: -0.32,
+      speed: 0,
+      velocitySpread: 0.025,
+    })
+}
+
+function emitJetpackSpark(origin: Vec3) {
+  smokeSystem.emit(origin, jetpackDown, {
+    colors: jetpackSparkColors,
+    count: 16,
+    glow: 2.1,
+    growthScale: 0.1,
+    lifeScale: 0.11,
+    originSpread: 0.04,
+    radiusJitter: 0.7,
+    radiusScale: 0.3,
+    rise: -2.1,
+    speed: 0,
+    velocitySpread: 0.18,
+  })
 }
 
 function updateSmokeMachines(stamp: number) {
@@ -5080,7 +5299,9 @@ const characterRenderSystem = createCharacterRenderSystem({
   gl,
   hairController,
   idleClipIndex: () => idleClipIndex,
+  jetpacking: () => localJetpackActionActive(),
   light: addLocalReflection,
+  loft: () => appSpace.kind === 'loft',
   localCharacter,
   localPoseUp,
   players: renderPlayers,

--- a/src/club-app.ts
+++ b/src/club-app.ts
@@ -2556,7 +2556,9 @@ let lastSprayAt = 0
 let sprayPointer = 0
 let jetpackPointer = 0
 let jetpackThrust = false
+let nextJetpackNetworkSyncAt = 0
 const sprayInterval = 55
+const jetpackNetworkSyncInterval = 120
 const graffitiPaintChunk = 25
 const graffitiAppendQueue: GraffitiSplat[] = []
 let graffitiSyncSnapshot: GraffitiSnapshot | undefined
@@ -3477,7 +3479,8 @@ canvas.addEventListener('pointerdown', event => {
     // Some browsers can reject capture if the pointer is no longer active.
   }
   if (hasMultiplayer) {
-    multiplayer.sendActionsIfChanged()
+    multiplayer.sendMotion()
+    multiplayer.sendActionsIfChanged(true)
   }
 }, { capture: true })
 
@@ -3549,7 +3552,8 @@ function stopJetpackThrust(pointerId = jetpackPointer) {
     }
   }
   if (hasMultiplayer) {
-    multiplayer.sendActionsIfChanged()
+    multiplayer.sendMotion()
+    multiplayer.sendActionsIfChanged(true)
   }
 }
 
@@ -4347,6 +4351,11 @@ const draw = (stamp: number) => {
   localCharacter.update(delta, cameraController.turn, outsideTree, styleController.bottomMode,
     jetpackEffective, inLoft, occupiedSeats,
     seat => takeNpcSeat(npcPlayers, seat, stamp * 0.001, outsideTree, occupiedSeats))
+  if (hasMultiplayer && localJetpackActionActive() && stamp >= nextJetpackNetworkSyncAt) {
+    nextJetpackNetworkSyncAt = stamp + jetpackNetworkSyncInterval
+    multiplayer.sendMotion()
+    multiplayer.sendActionsIfChanged(true)
+  }
   if (isAtLoftExitDoor()) {
     enterMain(true)
     scheduleFrame()
@@ -4724,7 +4733,7 @@ function emitJetpackSmoke(origin: Vec3, active: boolean) {
     ? {
       count: 4,
       growthScale: 1.2,
-      lifeScale: 0.28,
+      lifeScale: 1.4,
       originSpread: 0.045,
       radiusScale: 0.78,
       rise: -1.25,
@@ -4734,7 +4743,7 @@ function emitJetpackSmoke(origin: Vec3, active: boolean) {
     : {
       count: 1,
       growthScale: 0.7,
-      lifeScale: 0.22,
+      lifeScale: 1.1,
       originSpread: 0.025,
       radiusScale: 0.34,
       rise: -0.32,

--- a/src/local-character.ts
+++ b/src/local-character.ts
@@ -20,6 +20,9 @@ const waveDuration = 95 / 30
 const waveLoopStart = 28 / 30
 const waveLoopEnd = 62 / 30
 const breakdanceDuration = 201 / 30
+const jetpackAcceleration = 10
+const jetpackMaxVerticalSpeed = 2.8
+export const jetpackMaxEffectiveHeight = characterFloor + (outsideRooftop.height + upstairsWallHeight) * 0.5
 
 export function createLocalCharacter(keys: Set<string>) {
   const position: Vec3 = [-2.2, -1.95, -6.8]
@@ -200,6 +203,7 @@ export function createLocalCharacter(keys: Set<string>) {
       cameraTurn: number,
       outsideTree: CircleBounds,
       bottomMode: BottomMode,
+      jetpackThrust: boolean,
       loft: boolean,
       occupiedSeats: Set<string>,
       takeSeat: (seat: Seat) => void,
@@ -364,7 +368,8 @@ export function createLocalCharacter(keys: Set<string>) {
       }
 
       const jumping = wasJumping || jumpTime > 0
-      const collisionOptions = jumping ? { couches: false, duck: false } : { duck: false }
+      const thrusting = jetpackThrust && !jumping && mode !== 'breakdance'
+      const collisionOptions = jumping || thrusting ? { couches: false, duck: false } : { duck: false }
       const previousPosition: Vec3 = [position[0], position[1], position[2]]
 
       if (jumping) {
@@ -401,7 +406,9 @@ export function createLocalCharacter(keys: Set<string>) {
 
         position[0] += direction[0] * delta * 5
         position[2] += direction[2] * delta * 5
-        const foundSeat = !jumping && couchRelease <= 0 ? seatAt(position, occupiedSeats, 0.46, true, loft) : undefined
+        const foundSeat = !jumping && !thrusting && couchRelease <= 0
+          ? seatAt(position, occupiedSeats, 0.46, true, loft)
+          : undefined
         const nextSeat = foundSeat && (!hasDestination || foundSeat.id === destinationSeat) ? foundSeat : undefined
 
         if (nextSeat) {
@@ -446,12 +453,20 @@ export function createLocalCharacter(keys: Set<string>) {
         velocityY = 0
       }
       else {
-        velocityY -= 12 * delta
+        velocityY = thrusting
+          ? Math.min(jetpackMaxVerticalSpeed, velocityY + jetpackAcceleration * delta)
+          : velocityY - 12 * delta
         position[1] += velocityY * delta
 
         if (position[1] < floorY) {
           position[1] = floorY
           velocityY = 0
+        }
+      }
+      if (!jumping && position[1] > floorY + 0.02) {
+        motionBlend = 0
+        if (mode === 'run') {
+          mode = 'stand'
         }
       }
 

--- a/src/multiplayer.ts
+++ b/src/multiplayer.ts
@@ -504,11 +504,11 @@ export function createMultiplayer(options: {
       queue(encodeAdminMessage({ pass, command, id }))
     },
     sendMotion,
-    sendActionsIfChanged() {
+    sendActionsIfChanged(force = false) {
       const actions = options.localActions()
       const angle = angleToProtocol(options.localActionTurn())
 
-      if (actions !== lastActions || (actions !== 0 && angle !== lastActionAngle)) {
+      if (force || actions !== lastActions || (actions !== 0 && angle !== lastActionAngle)) {
         lastActions = actions
         lastActionAngle = angle
         send(encodeClientActions({ actions, angle }))

--- a/src/multiplayer.ts
+++ b/src/multiplayer.ts
@@ -4,6 +4,7 @@ import { lengthSq } from './math.ts'
 import {
   ACTION_BUBBLING,
   ACTION_FOAMING,
+  ACTION_JETPACK,
   ACTIONS,
   angleToProtocol,
   BEACH_BALLS,
@@ -332,6 +333,7 @@ export function createMultiplayer(options: {
         player.actionTurn = protocolToAngle(packet.angle)
         player.bubbling = (packet.actions & ACTION_BUBBLING) !== 0
         player.foaming = (packet.actions & ACTION_FOAMING) !== 0
+        player.jetpacking = (packet.actions & ACTION_JETPACK) !== 0
       }
 
       return

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -28,13 +28,14 @@ export const DUCK_POSITION = 24
 
 export const ACTION_BUBBLING = 1
 export const ACTION_FOAMING = 2
+export const ACTION_JETPACK = 4
 
 export const roomCount = 4
 export const messageMaxLength = 120
 export const instagramMaxLength = 30
 export const nicknameMaxLength = 32
 export const positionScale = 100
-export const protocolVersion = 53
+export const protocolVersion = 54
 
 const textEncoder = new TextEncoder()
 const textDecoder = new TextDecoder()

--- a/src/smoke-puff.ts
+++ b/src/smoke-puff.ts
@@ -6,8 +6,10 @@ import type { Vec3 } from './types.ts'
 export type SmokePuff = {
   position: Vec3
   velocity: Vec3
+  color: Vec3
   baseRadius: number
   growth: number
+  glow: number
   radius: number
   life: number
   maxLife: number
@@ -15,10 +17,14 @@ export type SmokePuff = {
 
 export type SmokeEmitOptions = {
   count: number
+  color?: Vec3
+  colors?: Vec3[]
   exhale?: boolean
+  glow?: number
   growthScale?: number
   lifeScale?: number
   originSpread?: number
+  radiusJitter?: number
   radiusScale?: number
   rise?: number
   speed?: number
@@ -45,8 +51,10 @@ function createPuff(): SmokePuff {
   return {
     position: [0, 0, 0],
     velocity: [0, 0, 0],
+      color: [0, 0, 0],
     baseRadius: 0,
     growth: 0,
+      glow: puffGlow,
     radius: 0,
     life: 0,
     maxLife: 0,
@@ -63,12 +71,17 @@ export function createSmokeSystem() {
     const velocitySpread = options.velocitySpread ?? drift
     const push = options.speed ?? (exhale ? 0.9 : 0.2)
     const radiusScale = options.radiusScale ?? 1
+    const radiusJitter = options.radiusJitter ?? 0
     const lift = options.rise ?? rise
     const lifeScale = options.lifeScale ?? 1
     const growthScale = options.growthScale ?? 1
+    const colors = options.colors
+    const color = options.color ?? smokeColor
+    const glow = options.glow ?? puffGlow
 
     for (let i = 0; i < options.count; i++) {
       const puff = pool.pop() ?? createPuff()
+      const nextColor = colors ? colors[Math.floor(random() * colors.length)]! : color
 
       puff.position[0] = origin[0] + (random() - 0.5) * spread
       puff.position[1] = origin[1] + (random() - 0.5) * spread
@@ -76,8 +89,12 @@ export function createSmokeSystem() {
       puff.velocity[0] = forward[0] * push + (random() - 0.5) * velocitySpread
       puff.velocity[1] = lift * (0.7 + random() * 0.6)
       puff.velocity[2] = forward[2] * push + (random() - 0.5) * velocitySpread
-      puff.baseRadius = (exhale ? puffRadius : wispRadius) * radiusScale
+      puff.color[0] = nextColor[0]
+      puff.color[1] = nextColor[1]
+      puff.color[2] = nextColor[2]
+      puff.baseRadius = (exhale ? puffRadius : wispRadius) * radiusScale * (1 + (random() - 0.5) * radiusJitter)
       puff.growth = growth * growthScale
+      puff.glow = glow
       puff.radius = puff.baseRadius
       puff.maxLife = (minLife + random() * (maxLife - minLife)) * lifeScale
       puff.life = puff.maxLife
@@ -124,7 +141,7 @@ export function writeSmokeGeometry(target: VertexWriter, puffs: SmokePuff[]) {
   reserveSphereFloats(target, unitSphere, puffs.length)
 
   for (const puff of puffs) {
-    writeSphere(target, unitSphere, puff.position[0], puff.position[1], puff.position[2], puff.radius, smokeColor,
-      puffGlow)
+    writeSphere(target, unitSphere, puff.position[0], puff.position[1], puff.position[2], puff.radius, puff.color,
+      puff.glow)
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,7 +177,7 @@ export type ResolvedPlayerStyle = {
   hairColor: Vec3
   skin: Vec3
   accessory?: Vec3
-  accessoryKind?: 'glowstick' | 'spray' | 'cigarette'
+  accessoryKind?: 'glowstick' | 'spray' | 'cigarette' | 'jetpack'
 }
 
 export type PlayerDestination = {
@@ -223,6 +223,7 @@ export type Player = {
   sunglasses?: boolean
   bubbling?: boolean
   foaming?: boolean
+  jetpacking?: boolean
   actionTurn?: number
 }
 


### PR DESCRIPTION
WIP

## Summary
- Temporary contribution adding a selectable `jetpack` accessory after the existing accessories, so existing saved accessory indexes are preserved.
- Holding primary click on the canvas while the jetpack is equipped activates thrust: the character ascends, keeps normal horizontal movement, falls naturally on release, and stops gaining lift past an altitude limit around half the tallest building height.
- Adds multiplayer-visible jetpack state, back-mounted pack/nozzle/handle geometry, dim/bright nozzle glow, idle smoke, active exhaust smoke, sparkles, sputter behavior at the altitude cap, and an airborne leg inertia pose.


https://github.com/user-attachments/assets/8ef3d00c-40fb-455e-a238-96cf99c97e84


https://github.com/user-attachments/assets/7abeea51-ff9a-45a5-b59a-db2325da6faf







## Test plan
- `bun run build`
- Manually checked locally while tuning: equip jetpack, hold/release click, move while airborne, observe altitude cap sputter, idle/active smoke and sparkles, nozzle glow, handles, and nozzle placement.

## Things to do
- Should not sit on benches etc. when jetpack is equipped.
- Test that it works well in multiplayer: other players see the jetpack, nozzle effects, particles, etc.
- Add a jetpack sound effect.